### PR TITLE
Parallelized beam hardening, specify start and end slices

### DIFF
--- a/bin/tomopy
+++ b/bin/tomopy
@@ -78,7 +78,7 @@ def run_rec(args):
     # update tomopy.conf
     sections = config.RECON_PARAMS
     config.write(args.config, args=args, sections=sections)
-
+    '''
     if (args.reconstruction_type == "slice") or (args.reconstruction_type == "full"):
     # add reconstruction command in ~/logs/user_last_name.log
         rec_log_msg = "\n" + "tomopy recon" + " --rotation-axis " + str(args.rotation_axis) \
@@ -94,25 +94,26 @@ def run_rec(args):
 
         log.info('  *** command to repeat the reconstruction: %s' % rec_log_msg)
         p = pathlib.Path(args.hdf_file)
-        lfname = os.path.join(args.logs_home, p.parts[-2] + '.log')
+        lfname = pathlib.Path.joinpath(pathlib.Path(args.logs_home), p.stem + '.log')
 
-        log.info('  *** command added to %s ' % lfname)
+        log.info('  *** command added to %s ' % lfname.as_posix())
         with open(lfname, "a") as myfile:
             myfile.write(rec_log_msg)
-
-    if (args.reconstruction_type == "full"):
+    '''
+    if (args.reconstruction_type == "slice") or (args.reconstruction_type == "full"):
         # copy tomopy.conf in the reconstructed data directory path
         # in this way you can reproduce the reconstruction by simply running:
         # $ tomopy recon --config /path/tomopy.conf
-        tail = os.sep + os.path.splitext(os.path.basename(args.hdf_file))[0]+ '_full_rec' + os.sep 
-        log_fname = os.path.dirname(args.hdf_file) + '_rec' + tail + os.path.split(args.config)[1]
+        config_path = pathlib.Path(args.config)
+        p = pathlib.Path(args.hdf_file)
+        log_fname = pathlib.Path.joinpath(p.parent, '_rec', p.stem + '_rec', config_path.name)
         try:
             shutil.copyfile(args.config, log_fname)
             log.info('  *** copied %s to %s ' % (args.config, log_fname))
         except:
-            log.error('  *** copied %s to %s failed' % (args.config, log_fname))
+            log.error('  *** attempt to copy %s to %s failed' % (args.config, log_fname))
             pass
-
+    log.info(' *** command to repeat the reconstruction: tomopy recon --config {:s}'.format(log_fname.as_posix()))
     log.warning('reconstruction end')
 
 

--- a/tomopy_cli/beamhardening.py
+++ b/tomopy_cli/beamhardening.py
@@ -28,16 +28,19 @@ Usage:
     to correct an image.
 
 '''
+from copy import deepcopy
+import os
+from pathlib import Path, PurePath
+
 import numpy as np
 import scipy.interpolate
 import scipy.integrate
 import h5py
-import os
-from pathlib import Path, PurePath
-from copy import deepcopy
 from scipy.interpolate import InterpolatedUnivariateSpline
 from scipy.signal import convolve
 from scipy.signal.windows import gaussian
+
+from tomopy.util.misc import mproc
 
 #Global variables we need for computing LUT
 filters = {}
@@ -317,7 +320,9 @@ def fcorrect_as_pathlength_centerline(input_trans):
     Input: transmission
     Output: sample pathlength in microns.
     """
-    return centerline_spline(input_trans)
+    data_dtype = input_trans.dtype
+    return_data = mproc.distribute_jobs(input_trans,centerline_spline,args=(),axis=1)
+    return return_data
 
 
 def fcorrect_as_pathlength(input_trans):

--- a/tomopy_cli/beamhardening.py
+++ b/tomopy_cli/beamhardening.py
@@ -40,7 +40,7 @@ from scipy.interpolate import InterpolatedUnivariateSpline
 from scipy.signal import convolve
 from scipy.signal.windows import gaussian
 
-from tomopy.util.misc import mproc
+from tomopy.util import mproc
 
 #Global variables we need for computing LUT
 filters = {}
@@ -346,7 +346,6 @@ def find_center_row(params):
         bright = bright[0,:]
     vertical_slice = np.sum(bright, axis=1)
     gaussian_filter = scipy.signal.windows.gaussian(200,20)
-    print(vertical_slice.shape, gaussian_filter.shape)
     filtered_slice = scipy.signal.convolve(vertical_slice, gaussian_filter,
                                             mode='same')
     center_row = float(np.argmax(filtered_slice))

--- a/tomopy_cli/config.py
+++ b/tomopy_cli/config.py
@@ -90,7 +90,15 @@ SECTIONS['file-reading'] = {
     'dark-zero': {
         'default': False,
         'help': 'When set, the the dark field is set to zero',
-        'action': 'store_true'}        
+        'action': 'store_true'},
+    'start-row': {
+        'default': 0,
+        'type': int,
+        'help': 'Row on which to start reconstructions'},
+    'end-row': {
+        'default': -1,
+        'type': int,
+        'help': 'Row on which to end reconstruction.  Negative values = last row of projection data.'}
        }
 
 SECTIONS['missing-angles'] = {

--- a/tomopy_cli/prep.py
+++ b/tomopy_cli/prep.py
@@ -146,7 +146,7 @@ def beamhardening_correct(data, params, sino):
     log.info("  *** correct beam hardening")
     data_dtype = data.dtype
     #Correct for centerline of fan
-    data = beamhardening.centerline_spline(data).astype(data_dtype)
+    data = beamhardening.correct_centerline(data)
     #Make an array of correction factors
     angles = np.abs(np.arange(sino[0], sino[1])- beamhardening.center_row).astype(data_dtype)
     angles *= beamhardening.pixel_size / beamhardening.d_source

--- a/tomopy_cli/prep.py
+++ b/tomopy_cli/prep.py
@@ -146,8 +146,10 @@ def beamhardening_correct(data, params, sino):
     log.info("  *** correct beam hardening")
     data_dtype = data.dtype
     #Correct for centerline of fan
-    data = beamhardening.correct_centerline(data)
+    data = beamhardening.fcorrect_as_pathlength_centerline(data)
     #Make an array of correction factors
+    beamhardening.center_row = params.center_row
+    log.info("Beam hardening center row = {:f}".format(beamhardening.center_row))
     angles = np.abs(np.arange(sino[0], sino[1])- beamhardening.center_row).astype(data_dtype)
     angles *= beamhardening.pixel_size / beamhardening.d_source
     log.info("  *** angles from {0:f} to {1:f} urad".format(angles[0], angles[-1]))

--- a/tomopy_cli/prep.py
+++ b/tomopy_cli/prep.py
@@ -143,12 +143,14 @@ def beamhardening_correct(data, params, sino):
     params: processing parameters
     sino: row numbers for these data
     """
+    log.info("  *** correct beam hardening")
     data_dtype = data.dtype
     #Correct for centerline of fan
     data = beamhardening.centerline_spline(data).astype(data_dtype)
     #Make an array of correction factors
-    angles = np.abs(np.arange(sino[0],sino[1])- beamhardening.center_row).astype(data_dtype)
+    angles = np.abs(np.arange(sino[0], sino[1])- beamhardening.center_row).astype(data_dtype)
     angles *= beamhardening.pixel_size / beamhardening.d_source
+    log.info("  *** angles from {0:f} to {1:f} urad".format(angles[0], angles[-1]))
     correction_factor = beamhardening.angular_spline(angles).astype(data_dtype)
     if len(data.shape) == 2:
         return data* correction_factor[:,None]

--- a/tomopy_cli/recon.py
+++ b/tomopy_cli/recon.py
@@ -66,7 +66,7 @@ def rec(params):
 
         # What if sino overruns the size of data?
         if sino[1] - sino[0] > proj.shape[1]:
-            sino[1] = sino[0] + proj.shape[1]
+            sino = (sino[0], sino[0] + proj.shape[1])
 
         # apply all preprocessing functions
         data = prep.all(proj, flat, dark, params, sino)

--- a/tomopy_cli/recon.py
+++ b/tomopy_cli/recon.py
@@ -35,10 +35,16 @@ def rec(params):
 
     # Select sinogram range to reconstruct
     if (params.reconstruction_type == "full"):
+        if params.start_row:
+            sino_start = params.start_row
+        else:
+            sino_start = 0
+        if params.end_row < 0:
+            sino_end = data_shape[1]
+        else:
+            sino_end = params.end_row 
         nSino_per_chunk = params.nsino_per_chunk
-        chunks = int(np.ceil(data_shape[1]/nSino_per_chunk))    
-        sino_start = 0
-        sino_end = chunks*nSino_per_chunk
+        chunks = int(np.ceil((sino_end - sino_start)/nSino_per_chunk))    
 
     else: # "slice" and "try"       
         nSino_per_chunk = pow(2, int(params.binning))
@@ -47,16 +53,18 @@ def rec(params):
         sino_start = ssino
         sino_end = sino_start + pow(2, int(params.binning)) 
 
-
     log.info("reconstructing [%d] slices from slice [%d] to [%d] in [%d] chunks of [%d] slices each" % \
                ((sino_end - sino_start)/pow(2, int(params.binning)), sino_start/pow(2, int(params.binning)), sino_end/pow(2, int(params.binning)), \
                chunks, nSino_per_chunk/pow(2, int(params.binning))))            
 
-    strt = 0
+    strt = sino_start
     for iChunk in range(0, chunks):
-        log.info('chunk # %i/%i' % (iChunk, chunks))
+        log.info('chunk # %i/%i' % (iChunk + 1, chunks))
         sino_chunk_start = np.int(sino_start + nSino_per_chunk*iChunk)
         sino_chunk_end = np.int(sino_start + nSino_per_chunk*(iChunk+1))
+        if sino_chunk_end > sino_end:
+            log.warning('  *** asking to go to row {0:d}, but our end row is {1:d}'.format(sino_chunk_end, sino_end))
+            sino_chunk_end = sino_end
         log.info('  *** [%i, %i]' % (sino_chunk_start/pow(2, int(params.binning)), sino_chunk_end/pow(2, int(params.binning))))
                 
         sino = (int(sino_chunk_start), int(sino_chunk_end))
@@ -66,6 +74,7 @@ def rec(params):
 
         # What if sino overruns the size of data?
         if sino[1] - sino[0] > proj.shape[1]:
+            log.warning(" *** Chunk size > remaining data size.")
             sino = (sino[0], sino[0] + proj.shape[1])
 
         # apply all preprocessing functions

--- a/tomopy_cli/recon.py
+++ b/tomopy_cli/recon.py
@@ -59,13 +59,14 @@ def rec(params):
         sino_chunk_end = np.int(sino_start + nSino_per_chunk*(iChunk+1))
         log.info('  *** [%i, %i]' % (sino_chunk_start/pow(2, int(params.binning)), sino_chunk_end/pow(2, int(params.binning))))
                 
-        if sino_chunk_end > sino_end: 
-            break
-
         sino = (int(sino_chunk_start), int(sino_chunk_end))
 
         # Read APS 32-BM raw data.
         proj, flat, dark, theta, rotation_axis = file_io.read_tomo(sino, params)
+
+        # What if sino overruns the size of data?
+        if sino[1] - sino[0] > proj.shape[1]:
+            sino[1] = sino[0] + proj.shape[1]
 
         # apply all preprocessing functions
         data = prep.all(proj, flat, dark, params, sino)
@@ -101,7 +102,7 @@ def rec(params):
 
         else: # "slice" and "full"
             rec = padded_rec(data, theta, rotation_axis, params)
-
+            '''
             # handling of the last chunk 
             if (params.reconstruction_type == "full"):
                 if(iChunk == chunks-1):
@@ -109,7 +110,7 @@ def rec(params):
                     log.info("  *** chunk # %d" % (chunks))
                     log.info("  *** last rec size %d" % ((data_shape[1]-(chunks-1)*nSino_per_chunk)/pow(2, int(params.binning))))
                     rec = rec[0:data_shape[1]-(chunks-1)*nSino_per_chunk,:,:]
-
+            '''
             # Save images
             if (params.reconstruction_type == "full"):
                 tail = os.sep + os.path.splitext(os.path.basename(params.hdf_file))[0]+ '_rec' + os.sep 


### PR DESCRIPTION
I added a few features since our work yesterday.  The beam hardening code now uses the multiprocessing features in tomopy, so it runs in parallel rather than serial.  I added some functionality for specifying a start and end row for the reconstruction.  I cleaned up the handling if our last row is past the last row of the dataset.  I was also having some trouble with the tomopy.conf file getting copied to the reconstruction directory at the end of the tomopy script, so I reworked the file naming a bit.