### PR TITLE
Add automated center of rotation.

### DIFF
--- a/bin/tomopy
+++ b/bin/tomopy
@@ -113,7 +113,7 @@ def run_rec(args):
         except:
             log.error('  *** attempt to copy %s to %s failed' % (args.config, log_fname))
             pass
-    log.info(' *** command to repeat the reconstruction: tomopy recon --config {:s}'.format(log_fname.as_posix()))
+    log.info(' *** command to repeat the reconstruction: tomopy recon --config {:s}'.format(str(log_fname)))
     log.warning('reconstruction end')
 
 

--- a/tomopy_cli/beam_hardening_data/setup.cfg
+++ b/tomopy_cli/beam_hardening_data/setup.cfg
@@ -1,10 +1,7 @@
 # This file gives configuration information for the beam hardening script.
 # Edit this file if you want to change the behavior of the file
 #
-# Paths: relative to the source code or an absolute path
-source_data_file: SRCOMPW
-#
-# Possible filters
+# Possible materials 
 symbol = Al, density = 2.7
 symbol = Be, density = 1.85
 symbol = Cu, density = 8.96

--- a/tomopy_cli/config.py
+++ b/tomopy_cli/config.py
@@ -519,8 +519,9 @@ def write_hdf(config_file, args=None, sections=None):
                     dset_length = len(str(value)) * 2 if len(str(value)) > 5 else 10
                     dt = 'S{0:d}'.format(dset_length)
                     hdf_file.require_dataset(dataset, shape=(1,), dtype=dt)
+                    log.info(name + ': ' + str(value))
                     try:
-                        hdf_file[dataset][0] = np.string_(value)
+                        hdf_file[dataset][0] = np.string_(str(value))
                     except TypeError:
                         print(value)
                         raise TypeError

--- a/tomopy_cli/file_io.py
+++ b/tomopy_cli/file_io.py
@@ -214,4 +214,4 @@ def read_rot_center(params):
             return rot_center
         except KeyError:
             log.warning('No rotation center stored in the HDF5 file.')
-            return None
+            return 0

--- a/tomopy_cli/find_center.py
+++ b/tomopy_cli/find_center.py
@@ -15,7 +15,7 @@ def find_rotation_axis(params):
     ra_fname = params.rotation_axis_file
 
     if os.path.isfile(fname):  
-        rot_center = _find_rotation_axis(params)
+        return _find_rotation_axis(params)
         
     elif os.path.isdir(fname):
         # Add a trailing slash if missing

--- a/tomopy_cli/recon.py
+++ b/tomopy_cli/recon.py
@@ -2,6 +2,7 @@ import os
 import sys
 import shutil
 import pathlib
+import threading
 import numpy as np
 import tomopy
 import dxchange
@@ -119,20 +120,15 @@ def rec(params):
 
         else: # "slice" and "full"
             rec = padded_rec(data, theta, rotation_axis, params)
-            '''
-            # handling of the last chunk 
-            if (params.reconstruction_type == "full"):
-                if(iChunk == chunks-1):
-                    log.info("handling of the last chunk")
-                    log.info("  *** chunk # %d" % (chunks))
-                    log.info("  *** last rec size %d" % ((data_shape[1]-(chunks-1)*nSino_per_chunk)/pow(2, int(params.binning))))
-                    rec = rec[0:data_shape[1]-(chunks-1)*nSino_per_chunk,:,:]
-            '''
             # Save images
             if (params.reconstruction_type == "full"):
                 tail = os.sep + os.path.splitext(os.path.basename(params.hdf_file))[0]+ '_rec' + os.sep 
                 fname = os.path.dirname(params.hdf_file) + '_rec' + tail + 'recon'
-                dxchange.write_tiff_stack(rec, fname=fname, start=strt)
+                write_thread = threading.Thread(target=dxchange.write_tiff_stack,
+                                                args = (rec,),
+                                                kwargs = {'fname':fname, 'start':strt})
+                write_thread.start()
+                #dxchange.write_tiff_stack(rec, fname=fname, start=strt)
                 strt += int((sino[1] - sino[0]) / np.power(2, float(params.binning)))
             if (params.reconstruction_type == "slice"):
                 fname = os.path.dirname(params.hdf_file)  + os.sep + 'slice_rec/recon_' + os.path.splitext(os.path.basename(params.hdf_file))[0]
@@ -222,7 +218,7 @@ def reconstruct(data, theta, rot_center, params):
         log.warning("  *** *** using: %s instead" % params.reconstruction_algorithm)
         log.warning("  *** *** sinogram_order: %s" % sinogram_order)
         rec = tomopy.recon(data, theta, center=rot_center, sinogram_order=sinogram_order, algorithm=params.reconstruction_algorithm, filter_name=params.filter)
-
+    log.info("  *** reconstruction finished")
     return rec
 
 
@@ -234,6 +230,7 @@ def mask(data, params):
         if 0 < params.reconstruction_mask_ratio <= 1:
             log.warning("  *** mask ratio: %f " % params.reconstruction_mask_ratio)
             data = tomopy.circ_mask(data, axis=0, ratio=params.reconstruction_mask_ratio)
+            log.info('  *** masking finished')
         else:
             log.error("  *** mask ratio must be between 0-1: %f is ignored" % params.reconstruction_mask_ratio)
     else:


### PR DESCRIPTION
I added an option to automatically calculate center of rotation if requested by the user and if one is not available in the DXchange file.

I cleaned up some of the documentation for beamhardening.py and some of the ancillary data files.

I was having trouble with the saving of the config parameters to the DXchange file.  I have h5py version 2.9 (the latest from Anaconda, I thought).  I changed the data type for saving so it works with older versions of h5py.