### PR TITLE
Added recon algorithms, gridrec bootstrapping of iterative schemes

### DIFF
--- a/tomopy_cli/config.py
+++ b/tomopy_cli/config.py
@@ -401,6 +401,22 @@ SECTIONS['astrasart'] = {
         'help': 'Number of requested iterations for ASTRA-SART per projection angle.'},
     }
 
+SECTIONS['astracgls'] = {
+    'astracgls-proj-type': {
+        'default': 'cuda',
+        'choices': ['cuda', 'linear'],
+        'type': str,
+        'help': 'Projection type for ASTRA-CGLS.  CPU = linear, GPU = cuda.'},
+    'astracgls-method': {
+        'default': 'CGLS_CUDA',
+        'type': str,
+        'help': 'Parameter passed to ASTRA for ASTRA-CGLS algorithm.'},
+    'astracgls-num_iter': {
+        'default': 200,
+        'type': util.positive_int,
+        'help': 'Number of requested iterations for ASTRA-CGLS.'},
+    }
+
 SECTIONS['iterative'] = {
     'iteration-count': {
         'default': 10,
@@ -410,14 +426,14 @@ SECTIONS['iterative'] = {
 
 RECON_PARAMS = ('find-rotation-axis', 'file-reading', 'missing-angles', 'zinger-removal', 'flat-correction', 'remove-stripe', 'fw', 
                 'ti', 'sf', 'retrieve-phase', 'beam-hardening', 'reconstruction', 'iterative',
-                'gridrec', 'lprec-fbp', 'astrasart', 'astrasirt')
+                'gridrec', 'lprec-fbp', 'astrasart', 'astrasirt', 'astracgls')
 FIND_CENTER_PARAMS = ('file-reading', 'find-rotation-axis')
 
 # PREPROC_PARAMS = ('flat-correction', 'remove-stripe', 'retrieve-phase')
 
 NICE_NAMES = ('General', 'Find rotation axis', 'File reading', 'Missing angles', 'Zinger removal', 'Flat correction', 'Retrieve phase', 
               'Remove stripe','Fourier wavelet', 'Titarenko', 'Smoothing filter', 'Beam hardening', 'Reconstruction', 'Iterative',
-                'Gridrec', 'LPRec FBP', 'ASTRA SART (GPU)', 'ASTRA SIRT (GPU)')
+                'Gridrec', 'LPRec FBP', 'ASTRA SART (GPU)', 'ASTRA SIRT (GPU)', 'ASTRA CGLS (GPU)')
 
 def get_config_name():
     """Get the command line --config option."""

--- a/tomopy_cli/config.py
+++ b/tomopy_cli/config.py
@@ -398,7 +398,7 @@ SECTIONS['astrasart'] = {
     'astrasart-num_iter': {
         'default': 200,
         'type': util.positive_int,
-        'help': 'Number of requested iterations for ASTRA-SART.'},
+        'help': 'Number of requested iterations for ASTRA-SART per projection angle.'},
     }
 
 SECTIONS['iterative'] = {
@@ -431,7 +431,6 @@ def get_config_name():
                 if name[0] == '=':
                     name = name[1:]
                 return name
-
     return name
 
 

--- a/tomopy_cli/config.py
+++ b/tomopy_cli/config.py
@@ -375,6 +375,10 @@ SECTIONS['astrasirt'] = {
         'default': 200,
         'type': util.positive_int,
         'help': 'Number of requested iterations for ASTRA-SIRT.'},
+    'astrasirt-bootstrap': {
+        'default': False,
+        'help': 'When set, gridrec is run first and used to initialize ASTRA-SIRT.',
+        'action': 'store_true',},
     }
 
 SECTIONS['astrasart'] = {
@@ -399,6 +403,10 @@ SECTIONS['astrasart'] = {
         'default': 200,
         'type': util.positive_int,
         'help': 'Number of requested iterations for ASTRA-SART per projection angle.'},
+    'astrasart-bootstrap': {
+        'default': False,
+        'help': 'When set, gridrec is run first and used to initialize ASTRA-SART.',
+        'action': 'store_true',},
     }
 
 SECTIONS['astracgls'] = {
@@ -415,24 +423,21 @@ SECTIONS['astracgls'] = {
         'default': 200,
         'type': util.positive_int,
         'help': 'Number of requested iterations for ASTRA-CGLS.'},
-    }
-
-SECTIONS['iterative'] = {
-    'iteration-count': {
-        'default': 10,
-        'type': util.positive_int,
-        'help': "Maximum number of iterations"},
+    'astracgls-bootstrap': {
+        'default': False,
+        'help': 'When set, gridrec is run first and used to initialize ASTRA-GCLS.',
+        'action': 'store_true',},
     }
 
 RECON_PARAMS = ('find-rotation-axis', 'file-reading', 'missing-angles', 'zinger-removal', 'flat-correction', 'remove-stripe', 'fw', 
-                'ti', 'sf', 'retrieve-phase', 'beam-hardening', 'reconstruction', 'iterative',
+                'ti', 'sf', 'retrieve-phase', 'beam-hardening', 'reconstruction', 
                 'gridrec', 'lprec-fbp', 'astrasart', 'astrasirt', 'astracgls')
 FIND_CENTER_PARAMS = ('file-reading', 'find-rotation-axis')
 
 # PREPROC_PARAMS = ('flat-correction', 'remove-stripe', 'retrieve-phase')
 
 NICE_NAMES = ('General', 'Find rotation axis', 'File reading', 'Missing angles', 'Zinger removal', 'Flat correction', 'Retrieve phase', 
-              'Remove stripe','Fourier wavelet', 'Titarenko', 'Smoothing filter', 'Beam hardening', 'Reconstruction', 'Iterative',
+              'Remove stripe','Fourier wavelet', 'Titarenko', 'Smoothing filter', 'Beam hardening', 'Reconstruction', 
                 'Gridrec', 'LPRec FBP', 'ASTRA SART (GPU)', 'ASTRA SIRT (GPU)', 'ASTRA CGLS (GPU)')
 
 def get_config_name():

--- a/tomopy_cli/recon.py
+++ b/tomopy_cli/recon.py
@@ -219,8 +219,11 @@ def reconstruct(data, theta, rot_center, params):
         data = np.roll(data, shift, axis=2)
         rec = tomopy.recon(data, theta, algorithm=tomopy.astra, options=options)
     elif params.reconstruction_algorithm == 'astracgls':
-        extra_options ={'MinConstraint':0}
-        options = {'proj_type':'cuda', 'method':'CGLS_CUDA', 'num_iter':15, 'extra_options':extra_options}
+        extra_options ={}
+        options = {'proj_type':params.astracgls_proj_type,
+                    'method': params.astracgls_method,
+                    'num_iter': params.astracgls_num_iter,
+                    'extra_options': extra_options,}
         shift = (int((data.shape[2]/2 - rot_center)+.5))
         data = np.roll(data, shift, axis=2)
         rec = tomopy.recon(data, theta, algorithm=tomopy.astra, options=options)

--- a/tomopy_cli/recon.py
+++ b/tomopy_cli/recon.py
@@ -198,9 +198,20 @@ def reconstruct(data, theta, rot_center, params):
                     'method': params.astrasirt_method,
                     'num_iter': params.astrasirt_num_iter,
                     'extra_options': extra_options,}
+        if params.astrasirt_bootstrap:
+            log.info('  *** *** bootstrapping with gridrec')
+            rec = tomopy.recon(data, theta, 
+                            center=rot_center, 
+                            sinogram_order=sinogram_order, 
+                            algorithm='gridrec', 
+                            filter_name=params.gridrec_filter)
         shift = (int((data.shape[2]/2 - rot_center)+.5))
         data = np.roll(data, shift, axis=2)
-        rec = tomopy.recon(data, theta, algorithm=tomopy.astra, options=options)
+        if params.astrasirt_bootstrap:
+            log.info('  *** *** using gridrec to start astrasirt recon')
+            rec = tomopy.recon(data, theta, init_recon=rec, algorithm=tomopy.astra, options=options)
+        else:
+            rec = tomopy.recon(data, theta, algorithm=tomopy.astra, options=options)
     elif params.reconstruction_algorithm == 'astrasart':
         extra_options ={}
         try:
@@ -215,8 +226,20 @@ def reconstruct(data, theta, rot_center, params):
                     'method': params.astrasart_method,
                     'num_iter': params.astrasart_num_iter * data.shape[0],
                     'extra_options': extra_options,}
+        if params.astrasart_bootstrap:
+            log.info('  *** *** bootstrapping with gridrec')
+            rec = tomopy.recon(data, theta, 
+                            center=rot_center, 
+                            sinogram_order=sinogram_order, 
+                            algorithm='gridrec', 
+                            filter_name=params.gridrec_filter)
         shift = (int((data.shape[2]/2 - rot_center)+.5))
         data = np.roll(data, shift, axis=2)
+        if params.astrasart_bootstrap:
+            log.info('  *** *** using gridrec to start astrasart recon')
+            rec = tomopy.recon(data, theta, init_recon=rec, algorithm=tomopy.astra, options=options)
+        else:
+            rec = tomopy.recon(data, theta, algorithm=tomopy.astra, options=options)
         rec = tomopy.recon(data, theta, algorithm=tomopy.astra, options=options)
     elif params.reconstruction_algorithm == 'astracgls':
         extra_options ={}
@@ -224,9 +247,20 @@ def reconstruct(data, theta, rot_center, params):
                     'method': params.astracgls_method,
                     'num_iter': params.astracgls_num_iter,
                     'extra_options': extra_options,}
+        if params.astracgls_bootstrap:
+            log.info('  *** *** bootstrapping with gridrec')
+            rec = tomopy.recon(data, theta, 
+                            center=rot_center, 
+                            sinogram_order=sinogram_order, 
+                            algorithm='gridrec', 
+                            filter_name=params.gridrec_filter)
         shift = (int((data.shape[2]/2 - rot_center)+.5))
         data = np.roll(data, shift, axis=2)
-        rec = tomopy.recon(data, theta, algorithm=tomopy.astra, options=options)
+        if params.astracgls_bootstrap:
+            log.info('  *** *** using gridrec to start astracgls recon')
+            rec = tomopy.recon(data, theta, init_recon=rec, algorithm=tomopy.astra, options=options)
+        else:
+            rec = tomopy.recon(data, theta, algorithm=tomopy.astra, options=options)
     elif params.reconstruction_algorithm == 'gridrec':
         log.warning("  *** *** sinogram_order: %s" % sinogram_order)
         rec = tomopy.recon(data, theta, 

--- a/tomopy_cli/recon.py
+++ b/tomopy_cli/recon.py
@@ -213,7 +213,7 @@ def reconstruct(data, theta, rot_center, params):
             log.warning('Invalid astrasart_max_constraint value.  Ignoring.')
         options = {'proj_type':params.astrasart_proj_type,
                     'method': params.astrasart_method,
-                    'num_iter': params.astrasart_num_iter,
+                    'num_iter': params.astrasart_num_iter * data.shape[0],
                     'extra_options': extra_options,}
         shift = (int((data.shape[2]/2 - rot_center)+.5))
         data = np.roll(data, shift, axis=2)


### PR DESCRIPTION
I made a separate section in the config file for each recon method.
I added in astra SART.
I reworked the tomopy_cli/recon.py so that the parameters for astra SIRT and astra CGLS were not hard coded, but came from the config file.
I also added an option to run gridrec before the iterative schemes, using this as an initial guess for the iterative scheme.
I tried to add LPrec FBP, but I haven't been able to test it yet.