### PR TITLE
Handling of --file-name /data/

### DIFF
--- a/bin/tomopy
+++ b/bin/tomopy
@@ -57,80 +57,58 @@ def run_seg(args):
 def run_rec(args):
 
     log.warning('reconstruction start')
-    if os.path.isfile(args.file_name):    
 
-        log.info("reconstructing a single file: %s" % args.file_name)   
-        recon.rec(args)
-
-    elif os.path.isdir(args.file_name):
-        if (str(args.file_format) in {'dx', 'aps2bm', 'aps7bm', 'aps32id'}):
+    if (str(args.file_format) in {'dx', 'aps2bm', 'aps7bm', 'aps32id'}):
+        if os.path.isfile(args.file_name):    
+            log.info("reconstructing a single file: %s" % args.file_name)   
+            recon.rec(args)
+            update(args)
+        elif os.path.isdir(args.file_name):
             # Add a trailing slash if missing
             top = os.path.join(args.file_name, '')
 
-            dictionary = file_io.read_rot_centers(args)
-            log.warning("reconstructing a folder containing %d files" % len(dictionary))   
-            index = 0
-            for key in dictionary:
-                dict2 = dictionary[key]
-                for h5fname in dict2:
-                    args.rotation_axis = dict2[h5fname]
-                    fname = top + h5fname
-                    args.file_name = fname
-                    log.warning("file %d/%d; ord(%s);  %s center: %f" % (index, len(dictionary)-1, key, args.file_name, args.rotation_axis))
-                    index += 1
-                    recon.rec(args)
+            h5_file_list = list(filter(lambda x: x.endswith(('.h5', '.hdf')), os.listdir(top)))
+            if (h5_file_list):
+                h5_file_list.sort()
+                log.info("found: %s" % h5_file_list) 
+                # look for pre-calculated rotation axis positions.
+                jfname = top + args.rotation_axis_file
+                print(str(jfname))
+                print(os.path.exists(jfname))
+                if(os.path.exists(jfname)):
+                    log.warning("try to use pre-calculated rotation centers from %s file" % jfname)   
+                    dictionary = file_io.read_rot_centers(args)
+                    # log.warning("reconstructing a folder containing %d files" % len(dictionary))   
+                    index = 0
+                    for key in dictionary:
+                        dict2 = dictionary[key]
+                        for h5fname in dict2:
+                            args.rotation_axis = dict2[h5fname]
+                            fname = top + h5fname
+                            args.file_name = fname
+                            log.warning("file %d/%d; ord(%s);  %s center: %f" % (index, len(dictionary)-1, key, args.file_name, args.rotation_axis))
+                            index += 1
+                            recon.rec(args)
+                            update(args)
+                    log.warning('reconstruction end')
+                else:
+                    log.warning("  *** no pre-calculated rotation centers from %s file" % jfname)   
+                    index=0
+                    for fname in h5_file_list:
+                        args.file_name = top + fname
+                        log.warning("  *** file %d/%d;  %s" % (index, len(h5_file_list), fname))
+                        index += 1
+                        recon.rec(args)
+                        update(args)
+                    log.warning('reconstruction end')
+            else:
+                log.error("directory %s does not contain any file" % args.file_name)
         else:
-            log.error("Directory or File Name does not exist: %s" % args.file_name)
-
-        # update tomopy.conf
-        sections = config.RECON_PARAMS
-        config.write(args.config, args=args, sections=sections)
-        '''
-        if (args.reconstruction_type == "slice") or (args.reconstruction_type == "full"):
-        # add reconstruction command in ~/logs/user_last_name.log
-            rec_log_msg = "\n" + "tomopy recon" + " --rotation-axis " + str(args.rotation_axis) \
-                                                + " --reconstruction-type " + str(args.reconstruction_type) \
-                                                + " --hdf-file " + str(args.file_name) \
-                                                + " --binning " + str(args.binning) \
-                                                + " --reconstruction-algorithm " + str(args.reconstruction_algorithm) \
-                                                + " --retrieve-phase-method " + str(args.retrieve_phase_method) \
-                                                + " --energy " + str(args.energy) \
-                                                + " --propagation-distance " + str(args.propagation_distance) \
-                                                + " --pixel-size " + str(args.pixel_size) \
-                                                + " --retrieve-phase-alpha  " + str(args.retrieve_phase_alpha)
-
-            log.info('  *** command to repeat the reconstruction: %s' % rec_log_msg)
-            p = pathlib.Path(args.file_name)
-            lfname = pathlib.Path.joinpath(pathlib.Path(args.logs_home), p.stem + '.log')
-
-            log.info('  *** command added to %s ' % lfname.as_posix())
-            with open(lfname, "a") as myfile:
-                myfile.write(rec_log_msg)
-        '''
-        if (args.reconstruction_type == "full"):
-        # if (args.reconstruction_type == "slice") or (args.reconstruction_type == "full"):
-            # copy tomopy.conf in the reconstructed data directory path
-            # in this way you can reproduce the reconstruction by simply running:
-            # $ tomopy recon --config /path/tomopy.conf
-
-            # config_path = pathlib.Path(args.config)
-            # p = pathlib.Path(args.file_name)
-            # log_fname = pathlib.Path.joinpath(p.parent, '_rec', p.stem + '_rec', config_path.name)
-            # un-did the above 
-            tail = os.sep + os.path.splitext(os.path.basename(args.file_name))[0]+ '_rec' + os.sep 
-            log_fname = os.path.dirname(args.file_name) + '_rec' + tail + os.path.split(args.config)[1]
-            try:
-                shutil.copyfile(args.config, log_fname)
-                log.info('  *** copied %s to %s ' % (args.config, log_fname))
-            except:
-                log.error('  *** attempt to copy %s to %s failed' % (args.config, log_fname))
-                pass
-            log.info(' *** command to repeat the reconstruction: tomopy recon --config {:s}'.format(log_fname))
-        log.warning('reconstruction end')
+            log.error("directory or File Name does not exist: %s" % args.file_name)
     else:
+        # add here support for other file formats
         log.error("  *** %s is not a supported file format" % args.file_format)
-        exit()
-
+        log.error("supported data formats are: %s, %s, %s, %s" % ('dx', 'aps2bm', 'aps7bm', 'aps32id'))
 
 
 def main():
@@ -180,6 +158,53 @@ def main():
         log.error(str(e))
         sys.exit(1)
 
+
+def update(args):
+       # update tomopy.conf
+        sections = config.RECON_PARAMS
+        config.write(args.config, args=args, sections=sections)
+        '''
+        if (args.reconstruction_type == "slice") or (args.reconstruction_type == "full"):
+        # add reconstruction command in ~/logs/user_last_name.log
+            rec_log_msg = "\n" + "tomopy recon" + " --rotation-axis " + str(args.rotation_axis) \
+                                                + " --reconstruction-type " + str(args.reconstruction_type) \
+                                                + " --hdf-file " + str(args.file_name) \
+                                                + " --binning " + str(args.binning) \
+                                                + " --reconstruction-algorithm " + str(args.reconstruction_algorithm) \
+                                                + " --retrieve-phase-method " + str(args.retrieve_phase_method) \
+                                                + " --energy " + str(args.energy) \
+                                                + " --propagation-distance " + str(args.propagation_distance) \
+                                                + " --pixel-size " + str(args.pixel_size) \
+                                                + " --retrieve-phase-alpha  " + str(args.retrieve_phase_alpha)
+
+            log.info('  *** command to repeat the reconstruction: %s' % rec_log_msg)
+            p = pathlib.Path(args.file_name)
+            lfname = pathlib.Path.joinpath(pathlib.Path(args.logs_home), p.stem + '.log')
+
+            log.info('  *** command added to %s ' % lfname.as_posix())
+            with open(lfname, "a") as myfile:
+                myfile.write(rec_log_msg)
+        '''
+        if (args.reconstruction_type == "full"):
+        # if (args.reconstruction_type == "slice") or (args.reconstruction_type == "full"):
+            # copy tomopy.conf in the reconstructed data directory path
+            # in this way you can reproduce the reconstruction by simply running:
+            # $ tomopy recon --config /path/tomopy.conf
+
+            # config_path = pathlib.Path(args.config)
+            # p = pathlib.Path(args.file_name)
+            # log_fname = pathlib.Path.joinpath(p.parent, '_rec', p.stem + '_rec', config_path.name)
+            # un-did the above 
+            tail = os.sep + os.path.splitext(os.path.basename(args.file_name))[0]+ '_rec' + os.sep 
+            log_fname = os.path.dirname(args.file_name) + '_rec' + tail + os.path.split(args.config)[1]
+            try:
+                shutil.copyfile(args.config, log_fname)
+                log.info('  *** copied %s to %s ' % (args.config, log_fname))
+            except:
+                log.error('  *** attempt to copy %s to %s failed' % (args.config, log_fname))
+                pass
+            log.info(' *** command to repeat the reconstruction: tomopy recon --config {:s}'.format(log_fname))
+ 
 
 if __name__ == '__main__':
     main()

--- a/tomopy_cli/config.py
+++ b/tomopy_cli/config.py
@@ -597,7 +597,7 @@ def write_hdf(config_file, args=None, sections=None):
     write values from *args* only to those sections, use the defaults on the remaining ones.
     """
     if not args.dx_update:
-        log.warning(" *** Not saving log data to the projection HDF file.")
+        log.warning("  *** Not saving log data to the projection HDF file.")
         return
     with h5py.File(args.hdf_file,'r+') as hdf_file:
         #If the group we will write to already exists, remove it

--- a/tomopy_cli/file_io.py
+++ b/tomopy_cli/file_io.py
@@ -219,7 +219,7 @@ def read_rot_centers(params):
     top = os.path.join(params.file_name, '')
 
     # Load the the rotation axis positions.
-    jfname = top + "rotation_axis.json"
+    jfname = top + params.rotation_axis_file
     
     try:
         with open(jfname) as json_file:
@@ -229,10 +229,10 @@ def read_rot_centers(params):
         return collections.OrderedDict(sorted(dictionary.items()))
 
     except Exception as error: 
-        log.error("ERROR: the json %s file containing the rotation axis locations is missing" % jfname)
-        log.error("ERROR: to create one run:")
-        log.error("ERROR: $ tomopy find_center --hdf-file %s" % top)
-        exit()
+        log.warning("the json %s file containing the rotation axis locations is missing" % jfname)
+        log.warning("to create one run:")
+        log.warning("$ tomopy find_center --file-name %s" % top)
+        # exit()
 
 
 def auto_read_dxchange(params):

--- a/tomopy_cli/find_center.py
+++ b/tomopy_cli/find_center.py
@@ -11,7 +11,7 @@ from tomopy_cli import file_io
 
 def find_rotation_axis(params):
 
-    fname = params.hdf_file
+    fname = params.file_name
     ra_fname = params.rotation_axis_file
 
     if os.path.isfile(fname):  
@@ -32,11 +32,11 @@ def find_rotation_axis(params):
         i=0
         for fname in h5_file_list:
             h5fname = top + fname
-            params.hdf_file = h5fname
+            params.file_name = h5fname
             rot_center = _find_rotation_axis(params)
-            params.hdf_file = top
+            params.file_name = top
             case =  {fname : rot_center}
-            log.info(case)
+            log.info("  *** file: %s; rotation axis %f" % (fname, rot_center))
             dic_centers[i] = case
             i += 1
 


### PR DESCRIPTION
There were inconsistencies on how the center of rotation was assigned  when passing a directory, i.e. between:
```
$ tomopy recon --file-name /data/data.h5
```
and
```
$ tomopy recon --file-name /data/
```
now the behavior is the same