### PR TITLE
added data converter for legacy data sets

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,7 @@ Installation
 ============
 
 ::
+
     $ git clone https://github.com/tomography/tomopy-cli.git
     $ cd tomopy-cli
     $ python setup.py install
@@ -16,6 +17,17 @@ Installation
 in a prepared virtualenv or as root for system-wide installation.
 
 .. warning:: If your python installation is in a location different from #!/usr/bin/env python please edit the first line of the bin/tomopy file to match yours.
+
+
+Update
+======
+
+**tomopy** is constantly updated to include new features. To update your locally installed version::
+
+    $ cd tomopy-cli
+    $ git pull
+    $ python setup.py install
+
 
 Dependencies
 ============

--- a/bin/tomopy
+++ b/bin/tomopy
@@ -52,6 +52,13 @@ def run_seg(args):
     sections = config.RECON_PARAMS
     config.write(args.config, args=args, sections=sections)
 
+
+def run_convert(args):
+
+    log.warning('convert start')
+    file_io.convert(args)
+    log.warning('convert end')
+
     
 def run_rec(args):
 
@@ -117,6 +124,7 @@ def main():
 
     tomo_params = config.RECON_PARAMS
     find_center_params = config.RECON_PARAMS
+    convert_params = config.CONVERT_PARAMS
 
     cmd_parsers = [
         ('init',        init,            (),                             "Create configuration file"),
@@ -124,6 +132,7 @@ def main():
         ('status',      run_status,      tomo_params,                    "Show the tomographic reconstruction status"),
         ('segment',     run_seg,         tomo_params,                    "Run segmentation on reconstured data"),
         ('find_center', run_find_center, find_center_params,             "Find rotation axis location for all hdf files in a directory"),
+        ('cenvert',     run_convert,     convert_params,                 "Convert pre-2015 (proj, dark, white) hdf files in a single data exchange h5 file"),
     ]
 
     subparsers = parser.add_subparsers(title="Commands", metavar='')

--- a/bin/tomopy
+++ b/bin/tomopy
@@ -132,7 +132,7 @@ def main():
         ('status',      run_status,      tomo_params,                    "Show the tomographic reconstruction status"),
         ('segment',     run_seg,         tomo_params,                    "Run segmentation on reconstured data"),
         ('find_center', run_find_center, find_center_params,             "Find rotation axis location for all hdf files in a directory"),
-        ('cenvert',     run_convert,     convert_params,                 "Convert pre-2015 (proj, dark, white) hdf files in a single data exchange h5 file"),
+        ('convert',     run_convert,     convert_params,                 "Convert pre-2015 (proj, dark, white) hdf files in a single data exchange h5 file"),
     ]
 
     subparsers = parser.add_subparsers(title="Commands", metavar='')

--- a/tomopy_cli/config.py
+++ b/tomopy_cli/config.py
@@ -438,16 +438,35 @@ SECTIONS['astracgls'] = {
         'action': 'store_true',},
     }
 
+SECTIONS['convert'] = {
+    'old-projection-file-name': {
+        'default': '.',
+        'type': str,
+        'help': "Name of the hdf file containing the projections",
+        'metavar': 'PATH'},
+    'old-dark-file-name': {
+        'default': '.',
+        'type': str,
+        'help': "Name of the hdf file containing the dark images",
+        'metavar': 'PATH'},
+    'old-white-file-name': {
+        'default': '.',
+        'type': str,
+        'help': "Name of the hdf file containing the white images",
+        'metavar': 'PATH'},
+        }
+
 RECON_PARAMS = ('find-rotation-axis', 'file-reading', 'dx-options', 'missing-angles', 'zinger-removal', 'flat-correction', 'remove-stripe', 'fw', 
                 'ti', 'sf', 'retrieve-phase', 'beam-hardening', 'reconstruction', 
                 'gridrec', 'lprec-fbp', 'astrasart', 'astrasirt', 'astracgls')
 FIND_CENTER_PARAMS = ('file-reading', 'find-rotation-axis', 'dx-options')
 
+CONVERT_PARAMS = ('convert', )
 # PREPROC_PARAMS = ('flat-correction', 'remove-stripe', 'retrieve-phase')
 
 NICE_NAMES = ('General', 'Find rotation axis', 'File reading', 'dx-options', 'Missing angles', 'Zinger removal', 'Flat correction', 'Retrieve phase', 
               'Remove stripe','Fourier wavelet', 'Titarenko', 'Smoothing filter', 'Beam hardening', 'Reconstruction', 
-                'Gridrec', 'LPRec FBP', 'ASTRA SART (GPU)', 'ASTRA SIRT (GPU)', 'ASTRA CGLS (GPU)')
+                'Gridrec', 'LPRec FBP', 'ASTRA SART (GPU)', 'ASTRA SIRT (GPU)', 'ASTRA CGLS (GPU)', 'Convert')
 
 def get_config_name():
     """Get the command line --config option."""

--- a/tomopy_cli/file_io.py
+++ b/tomopy_cli/file_io.py
@@ -5,6 +5,7 @@ import collections
 import tomopy
 import dxchange
 import dxchange.reader as dxreader
+import dxfile.dxtomo as dx
 import numpy as np
 
 from tomopy_cli import log
@@ -339,10 +340,10 @@ def convert(params):
     flat_grp = '/'.join([exchange_base, 'data_white'])
     dark_grp = '/'.join([exchange_base, 'data_dark'])
     theta_grp = '/'.join([exchange_base, 'theta'])
-    tomo = read_hdf5(params.old_projection_file_name, tomo_grp)
-    flat = read_hdf5(params.old_white_file_name, flat_grp)
-    dark = read_hdf5(params.old_dark_file_name, dark_grp)
-    theta = read_hdf5(params.old_projection_file_name, theta_grp)
+    tomo = dxreader.read_hdf5(params.old_projection_file_name, tomo_grp)
+    flat = dxreader.read_hdf5(params.old_white_file_name, flat_grp)
+    dark = dxreader.read_hdf5(params.old_dark_file_name, dark_grp)
+    theta = dxreader.read_hdf5(params.old_projection_file_name, theta_grp)
 
     # Open DataExchange file
     f = dx.File(new_hdf_file_name, mode='w') 

--- a/tomopy_cli/file_io.py
+++ b/tomopy_cli/file_io.py
@@ -322,4 +322,34 @@ def read_scintillator(params):
     #be computed later.
     if params.beam_hardening_method.lower() == 'standard':
         beamhardening.initialize(params)
-    return params 
+    return params
+
+
+def convert(params):
+
+    head_tail = os.path.split(params.old_projection_file_name)
+
+    new_hdf_file_name = head_tail[0] + os.sep + os.path.splitext(head_tail[1])[0] + '.h5'
+
+    print('converting data file: %s in new format: %s' % (params.old_projection_file_name, new_hdf_file_name))
+    print('using %s as dark and %s as white field' %(params.old_dark_file_name, params.old_white_file_name))
+    exchange_base = "exchange"
+
+    tomo_grp = '/'.join([exchange_base, 'data'])
+    flat_grp = '/'.join([exchange_base, 'data_white'])
+    dark_grp = '/'.join([exchange_base, 'data_dark'])
+    theta_grp = '/'.join([exchange_base, 'theta'])
+    tomo = read_hdf5(params.old_projection_file_name, tomo_grp)
+    flat = read_hdf5(params.old_white_file_name, flat_grp)
+    dark = read_hdf5(params.old_dark_file_name, dark_grp)
+    theta = read_hdf5(params.old_projection_file_name, theta_grp)
+
+    # Open DataExchange file
+    f = dx.File(new_hdf_file_name, mode='w') 
+
+    f.add_entry(dx.Entry.data(data={'value': tomo, 'units':'counts'}))
+    f.add_entry(dx.Entry.data(data_white={'value': flat, 'units':'counts'}))
+    f.add_entry(dx.Entry.data(data_dark={'value': dark, 'units':'counts'}))
+    f.add_entry(dx.Entry.data(theta={'value': theta, 'units':'degrees'}))
+
+    f.close()


### PR DESCRIPTION
At one point one of the fast PCO camera were saving 3 hdf data sets (proj, white, dark). To accommodate a request to be able to reprocess those data with tomopy-cli we added a converter.
This function is not touching the tomopy.config, i.e. is not interfering with any of the preset parameters