### PR TITLE
Debugging flip-and-stitch reconstructions and find_center

### DIFF
--- a/bin/tomopy
+++ b/bin/tomopy
@@ -32,7 +32,7 @@ def run_find_center(args):
 
     if (str(args.file_format) in {'dx', 'aps2bm', 'aps7bm', 'aps32id'}):
         log.warning('find center start')
-        find_center.find_rotation_axis(args)
+        args = find_center.find_rotation_axis(args)
         log.warning('find center end')
 
         # update tomopy.conf

--- a/tomopy_cli/beamhardening.py
+++ b/tomopy_cli/beamhardening.py
@@ -372,8 +372,8 @@ def find_center_row(params):
     with h5py.File(params.file_name,'r') as hdf_file:
         bright = hdf_file['/exchange/data_white'][...]
     if len(bright.shape) > 2:
-        bright = bright[0,:]
-    vertical_slice = np.sum(bright, axis=1)
+        bright = bright[-1,...]
+    vertical_slice = np.sum(bright, axis=1, dtype=np.float64)
     gaussian_filter = scipy.signal.windows.gaussian(200,20)
     filtered_slice = scipy.signal.convolve(vertical_slice, gaussian_filter,
                                             mode='same')

--- a/tomopy_cli/find_center.py
+++ b/tomopy_cli/find_center.py
@@ -5,7 +5,6 @@ import numpy as np
 import h5py
 from skimage.filters import gaussian
 import skimage.feature
-import matplotlib.pyplot as plt
 
 from tomopy_cli import log
 from tomopy_cli import prep

--- a/tomopy_cli/find_center.py
+++ b/tomopy_cli/find_center.py
@@ -3,9 +3,13 @@ import json
 import tomopy
 import numpy as np
 import h5py
+from skimage.filters import gaussian
+import skimage.feature
+import matplotlib.pyplot as plt
 
 from tomopy_cli import log
 from tomopy_cli import prep
+from tomopy_cli import config
 from tomopy_cli import file_io
 
 
@@ -58,6 +62,9 @@ def _find_rotation_axis(params):
     log.info("  *** calculating automatic center")
     data_size = file_io.get_dx_dims(params)
     ssino = int(data_size[1] * params.nsino)
+    params = file_io.read_pixel_size(params)
+    params = file_io.read_scintillator(params)
+    params = file_io.read_bright_ratio(params)
 
     # Select sinogram range to reconstruct
     sino_start = ssino
@@ -66,14 +73,51 @@ def _find_rotation_axis(params):
     sino = (int(sino_start), int(sino_end))
 
     # Read APS 32-BM raw data
-    proj, flat, dark, theta, params_rotation_axis_ignored = file_io.read_tomo(sino, params)
+    proj, flat, dark, theta, params_rotation_axis_ignored = file_io.read_tomo(sino, params, True)
         
     # apply all preprocessing functions
     data = prep.all(proj, flat, dark, params, sino)
 
-    # find rotation center
-    log.info("  *** find_center vo")
-    rot_center = tomopy.find_center_vo(data)   
-    log.info("  *** automatic center: %f" % rot_center)
+    # if flip and stitch, just use the overlapped part of the dataset
+    if params.file_type == 'flip_and_stich':
+        params = _find_rotation_axis_flip_stitch(data, params)
+    else:        
+        # find rotation center
+        log.info("  *** find_center vo")
+        # if we start at 0 and end at 180, remove last angle
+        if np.isclose(theta[-1] - theta[0], np.pi, 1e-4):
+            data = data[:-1,...]
+        params.rotation_axis = tomopy.find_center_vo(data) * np.power(2, float(params.binning))
+        params.rotation_axis_flip = -1
+    log.info("  *** automatic center: %f" % params.rotation_axis)
+    return params
 
-    return rot_center * np.power(2, float(params.binning))
+
+def _find_rotation_axis_flip_stitch(data, params):
+    '''Code to find the center of rotation for a flip-and-stitch scan.
+    Unlike for 0-180 degree scans, we have images from two angles
+    180 degrees apart to compare in the region viewed at all angles.
+    '''
+    log.info('  *** *** finding rotation axis for flip-and-stitch scan')
+    log.info(data.shape)
+    #Make images of the two halves of the sinogram
+    half_num_angles = data.shape[0]//2
+    img_0_180 = data[:half_num_angles,0,:]
+    img_180_360 = data[half_num_angles:2 * half_num_angles,0,::-1]
+    #img_180_360 = np.roll(img_0_180, 1, axis=1)
+    log.info('  *** *** shape of images to correlate is ({0:d}, {1:d})'
+                .format(*img_0_180.shape)) 
+    #Do an unsharp mask on these to get only the fine features and zero mean
+    img_0_180 -= skimage.filters.gaussian(img_0_180, sigma=10, mode='reflect')
+    img_180_360 -= skimage.filters.gaussian(img_180_360, sigma=10, mode='reflect')
+    correlation_matrix = skimage.feature.match_template(img_0_180, img_180_360, pad_input=True)
+    match_location = np.argmax(correlation_matrix[half_num_angles//2,:])
+    axis_shift = (match_location - data.shape[2] / 2) / 2.0
+    log.info('  *** *** match location = {:d}'.format(match_location))
+    log.info('  *** *** axis shift = {:f}'.format(axis_shift))
+    params.rotation_axis_flip = data.shape[2] / 2 - 0.5 + axis_shift
+    new_size = data.shape[2] + np.abs(axis_shift) * 2.0
+    params.rotation_axis = new_size / 2 - 0.5
+    log.info('  *** *** rotation axis before stitch = {:f}'.format(params.rotation_axis_flip))
+    log.info('  *** *** rotation axis = {:f}'.format(params.rotation_axis))
+    return params

--- a/tomopy_cli/prep.py
+++ b/tomopy_cli/prep.py
@@ -3,11 +3,9 @@ import json
 import tomopy
 import dxchange
 import numpy as np
-import matplotlib.pyplot as plt
 
 from tomopy_cli import log
 from tomopy_cli import file_io
-from tomopy_cli import prep
 from tomopy_cli import beamhardening
 
 def all(proj, flat, dark, params, sino):

--- a/tomopy_cli/prep.py
+++ b/tomopy_cli/prep.py
@@ -3,6 +3,7 @@ import json
 import tomopy
 import dxchange
 import numpy as np
+import matplotlib.pyplot as plt
 
 from tomopy_cli import log
 from tomopy_cli import file_io
@@ -10,10 +11,8 @@ from tomopy_cli import prep
 from tomopy_cli import beamhardening
 
 def all(proj, flat, dark, params, sino):
-
     # zinger_removal
     proj, flat = zinger_removal(proj, flat, params)
-
     if (params.dark_zero):
         dark *= 0
         log.warning('  *** *** dark fields are ignored')
@@ -32,7 +31,6 @@ def all(proj, flat, dark, params, sino):
         data = minus_log(data, params)
     # remove outlier
     data = remove_nan_neg_inf(data, params)
-
     return data
 
 
@@ -72,6 +70,11 @@ def flat_correction(proj, flat, dark, params):
     log.info('  *** normalization')
     if(params.flat_correction_method == 'standard'):
         data = tomopy.normalize(proj, flat, dark, cutoff=params.normalization_cutoff)
+        try:
+            if params.bright_exp_ratio != 1:
+                data *= params.bright_exp_ratio
+        except AttributeError:
+            log.warning('  *** *** No bright_exp_ratio found.  Ignore')
         log.info('  *** *** ON %f cut-off' % params.normalization_cutoff)
     elif(params.flat_correction_method == 'air'):
         data = tomopy.normalize_bg(proj, air=params.air)

--- a/tomopy_cli/recon.py
+++ b/tomopy_cli/recon.py
@@ -7,7 +7,6 @@ import threading
 import numpy as np
 import tomopy
 import dxchange
-import matplotlib.pyplot as plt
 
 from tomopy_cli import log
 from tomopy_cli import file_io

--- a/tomopy_cli/recon.py
+++ b/tomopy_cli/recon.py
@@ -78,15 +78,6 @@ def rec(params):
         # Reconstruct
         if (params.reconstruction_type == "try"):
             # try passes an array of rotation centers and this is only supported by gridrec
-            plt.imshow(data[:,0,:], vmin=3200, vmax=3600)
-            plt.colorbar()
-            plt.figure()
-            plt.imshow(proj[:,0,:])
-            plt.colorbar()
-            plt.figure()
-            plt.imshow(flat[:,0,:])
-            plt.colorbar()
-            plt.show()
             reconstruction_algorithm_org = params.reconstruction_algorithm
             params.reconstruction_algorithm = 'gridrec'
 

--- a/tomopy_cli/recon.py
+++ b/tomopy_cli/recon.py
@@ -7,6 +7,7 @@ import threading
 import numpy as np
 import tomopy
 import dxchange
+import matplotlib.pyplot as plt
 
 from tomopy_cli import log
 from tomopy_cli import file_io
@@ -77,6 +78,15 @@ def rec(params):
         # Reconstruct
         if (params.reconstruction_type == "try"):
             # try passes an array of rotation centers and this is only supported by gridrec
+            plt.imshow(data[:,0,:], vmin=3200, vmax=3600)
+            plt.colorbar()
+            plt.figure()
+            plt.imshow(proj[:,0,:])
+            plt.colorbar()
+            plt.figure()
+            plt.imshow(flat[:,0,:])
+            plt.colorbar()
+            plt.show()
             reconstruction_algorithm_org = params.reconstruction_algorithm
             params.reconstruction_algorithm = 'gridrec'
 


### PR DESCRIPTION
This commit incorporates changes to allow for automated rotation axis determination for flip-and-stitch scans, as well as the reconstructions.  I also implemented median filtering the image stack if the data_white and data_dark datasets are 3D.