### PR TITLE
Added options for automatically reading the filters from HDF5 file.

### DIFF
--- a/tests/test_file_io.py
+++ b/tests/test_file_io.py
@@ -1,6 +1,8 @@
 import unittest
 from unittest import mock
+import os
 
+import h5py
 import numpy as np
 from tomopy.misc import phantom
 from tomopy import misc, project
@@ -24,3 +26,82 @@ class FlipAndStitchTests(unittest.TestCase):
             params, img360=sino360, flat360=sino360, dark360=sino360)
         # Test the result
         self.assertEqual(sino180.shape, (181, 1, 183))
+
+
+class ReadParamTests(unittest.TestCase):
+    test_hdf_file = 'filter-tests.hdf5'
+    # Sample filters from 7-BM-B for 'open' and 'Cu_1000um' filters
+    filter_open = np.array([[79, 112, 101, 110,] + [0,] * 252], dtype='int8')
+    filter_Cu_1000um = np.array([[67, 117,  95,  49,  48,  48, 48, 117, 109,] + [0,] * 247], dtype='int8')
+    
+    def tearDown(self):
+        # Clean up the mocked HDF5 file
+        if os.path.exists(self.test_hdf_file):
+            os.remove(self.test_hdf_file)
+    
+    def prepare_hdf_file(self, filter_1=None, filter_2=None):
+        with h5py.File(self.test_hdf_file, mode='x') as h5fp:
+            if filter_1 is not None:
+                h5fp['measurement/instrument/filters/Filter_1_Material'] = filter_1
+            if filter_2 is not None:
+                h5fp['measurement/instrument/filters/Filter_2_Material'] = filter_2
+    
+    def test_filter_str_to_params(self):
+        self.assertEqual(
+            file_io._filter_str_to_params('Open'),
+            ('Al', 0.),
+        )
+        self.assertEqual(
+            file_io._filter_str_to_params('Cu_1000um'),
+            ('Cu', 1000.),
+        )
+        self.assertEqual(
+            file_io._filter_str_to_params('Pb_102.0'),
+            ('Pb', 102.),
+        )
+        self.assertEqual(
+            file_io._filter_str_to_params('gibberish'),
+            ('Al', 0.),
+        )
+        self.assertEqual(
+            file_io._filter_str_to_params('LuAG_Ce_1000um'),
+            ('LuAG_Ce', 1000.),
+        )
+            
+    def test_read_real_filter_materials(self):
+        # Prepare mocked HDF5 file
+        self.prepare_hdf_file(filter_1=self.filter_open, filter_2=self.filter_Cu_1000um)
+        # Prepare mocked config parameters
+        params = mock.MagicMock()
+        params.file_name = self.test_hdf_file
+        params.filter_1_material = 'auto'
+        params.filter_1_thickness = 0.
+        params.filter_2_material = 'auto'
+        params.filter_2_thickness = 0.
+        # Call code under test
+        file_io.read_filter_materials(params)
+        # Check that the params were updated correctly
+        self.assertEqual(params.filter_1_material, 'Al')
+        self.assertEqual(params.filter_1_thickness, 0.)
+        self.assertEqual(params.filter_2_material, 'Cu')
+        self.assertEqual(params.filter_2_thickness, 1000.)
+    
+    def test_read_missing_filter_materials(self):
+        # Prepare mocked HDF5 file
+        self.prepare_hdf_file(filter_1=None, filter_2=None)
+        # Prepare mocked config parameters
+        params = mock.MagicMock()
+        params.file_name = self.test_hdf_file
+        params.filter_1_material = 'auto'
+        params.filter_1_thickness = 100.
+        params.filter_2_material = 'auto'
+        params.filter_2_thickness = 100.
+        # Call code under test
+        import logging
+        log = logging.getLogger(__name__)
+        file_io.read_filter_materials(params)
+        # Check that the params were updated correctly
+        self.assertEqual(params.filter_1_material, 'Al')
+        self.assertEqual(params.filter_1_thickness, 0.)
+        self.assertEqual(params.filter_2_material, 'Al')
+        self.assertEqual(params.filter_2_thickness, 0.)

--- a/tomopy_cli/config.py
+++ b/tomopy_cli/config.py
@@ -294,19 +294,19 @@ SECTIONS['beam-hardening']= {
         'help': 'Sample material for beam hardening',
         'choices': ['Al','Be','Cu','Fe','Ge','Inconel625','LuAG_Ce','LYSO_Ce','Mo','Pb','Si','SS316','Ta','Ti_6_4','W','YAG_Ce']},
     'filter-1-material': {
-        'default': 'none',
+        'default': 'auto',
         'type': str,
         'help': 'Filter 1 material for beam hardening',
-        'choices': ['none','Al','Be','Cu','Fe','Ge','Inconel625','LuAG_Ce','LYSO_Ce','Mo','Pb','Si','SS316','Ta','Ti_6_4','W','YAG_Ce']},
+        'choices': ['auto','none','Al','Be','Cu','Fe','Ge','Inconel625','LuAG_Ce','LYSO_Ce','Mo','Pb','Si','SS316','Ta','Ti_6_4','W','YAG_Ce']},
     'filter-1-thickness': {
         'default': 0.0,
         'type': float,
         'help': 'Filter 1 thickness for beam hardening'},
     'filter-2-material': {
-        'default': 'none',
+        'default': 'auto',
         'type': str,
         'help': 'Filter 2 material for beam hardening',
-        'choices': ['none','Al','Be','Cu','Fe','Ge','Inconel625','LuAG_Ce','LYSO_Ce','Mo','Pb','Si','SS316','Ta','Ti_6_4','W','YAG_Ce']},
+        'choices': ['auto','none','Al','Be','Cu','Fe','Ge','Inconel625','LuAG_Ce','LYSO_Ce','Mo','Pb','Si','SS316','Ta','Ti_6_4','W','YAG_Ce']},
     'filter-2-thickness': {
         'default': 0.0,
         'type': float,

--- a/tomopy_cli/find_center.py
+++ b/tomopy_cli/find_center.py
@@ -62,6 +62,7 @@ def _find_rotation_axis(params):
     data_size = file_io.get_dx_dims(params)
     ssino = int(data_size[1] * params.nsino)
     params = file_io.read_pixel_size(params)
+    params = file_io.read_filter_materials(params)
     params = file_io.read_scintillator(params)
     params = file_io.read_bright_ratio(params)
 


### PR DESCRIPTION
I had beamtime at 7-BM and we switched filters several times. I keep forgetting to update my base config file with the new filters, so I wanted a way to load them from the HDF5 file when the first reconstruction is done.

The ``config.py`` file has a new default option for *filter_1_material* and
*filter_2_material*. The new default value "auto" instructs tomopy-cli to read
the filter configuration from the measurement meta-data stored in the
HDF5 file. If the filter is open, no meta-data are found, or the
meta-data are not in the expected format, a 0 µm thick Al filter will
be used.

This PR also cleans up some of the logging calls for indentation,
etc., and fixes a bug in automatic rotation finding.