### PR TITLE
Minor change to config.py defaults

### DIFF
--- a/tomopy_cli/config.py
+++ b/tomopy_cli/config.py
@@ -183,7 +183,7 @@ SECTIONS['flat-correction'] = {
         'help': "Fix nan and inf",
         'action': 'store_true'},
     'fix-nan-and-inf-value': {
-        'default': 0.0,
+        'default': 6.0,
         'type': float,
         'help': "Values to be replaced with negative values in array"},
     'minus-log': {
@@ -295,7 +295,7 @@ SECTIONS['beam-hardening']= {
         'help': 'Sample material for beam hardening',
         'choices': ['Al','Be','Cu','Fe','Ge','Inconel625','LuAG_Ce','LYSO_Ce','Mo','Pb','Si','SS316','Ta','Ti_6_4','W','YAG_Ce']},
     'filter-1-material': {
-        'default': 'auto',
+        'default': 'none',
         'type': str,
         'help': 'Filter 1 material for beam hardening',
         'choices': ['auto','none','Al','Be','Cu','Fe','Ge','Inconel625','LuAG_Ce','LYSO_Ce','Mo','Pb','Si','SS316','Ta','Ti_6_4','W','YAG_Ce']},
@@ -304,7 +304,7 @@ SECTIONS['beam-hardening']= {
         'type': float,
         'help': 'Filter 1 thickness for beam hardening'},
     'filter-2-material': {
-        'default': 'auto',
+        'default': 'none',
         'type': str,
         'help': 'Filter 2 material for beam hardening',
         'choices': ['auto','none','Al','Be','Cu','Fe','Ge','Inconel625','LuAG_Ce','LYSO_Ce','Mo','Pb','Si','SS316','Ta','Ti_6_4','W','YAG_Ce']},
@@ -313,12 +313,12 @@ SECTIONS['beam-hardening']= {
         'type': float,
         'help': 'Filter 2 thickness for beam hardening'},
     'filter-3-material': {
-        'default': 'Be',
+        'default': 'none',
         'type': str,
         'help': 'Filter 3 material for beam hardening',
         'choices': ['none','Al','Be','Cu','Fe','Ge','Inconel625','LuAG_Ce','LYSO_Ce','Mo','Pb','Si','SS316','Ta','Ti_6_4','W','YAG_Ce']},
     'filter-3-thickness': {
-        'default': 750.0,
+        'default': 0.0,
         'type': float,
         'help': 'Filter 3 thickness for beam hardening'},
     }

--- a/tomopy_cli/prep.py
+++ b/tomopy_cli/prep.py
@@ -39,8 +39,8 @@ def remove_nan_neg_inf(data, params):
         log.info('  *** *** ON')
         log.info('  *** *** replacement value %f ' % params.fix_nan_and_inf_value)
         data = tomopy.remove_nan(data, val=params.fix_nan_and_inf_value)
-        data = tomopy.remove_neg(data, val=params.fix_nan_and_inf_value)
-        data[np.where(data == np.inf)] = params.fix_nan_and_inf_value
+        data = tomopy.remove_neg(data, val= 0.0)
+        data[np.isinf(data)] = params.fix_nan_and_inf_value
         data[data > params.fix_nan_and_inf_value] = params.fix_nan_and_inf_value
     else:
         log.warning('  *** *** OFF')


### PR DESCRIPTION
I changed the defaults for:
fix_nan_and_inf_value to 6.0.  If this is in extinction lengths, this would represent a transmission of 0.0037.
filter-1-material, filter-2-material, and filter-3-material to none.  This keeps the auto filter retrieval from activating unless the user explicitly asks for it.