### PR TITLE
HDF output

### DIFF
--- a/tests/test_file_io.py
+++ b/tests/test_file_io.py
@@ -133,8 +133,8 @@ class WriteHDF5Tests(unittest.TestCase):
             # Check that the target data were saved in the right place
             np.testing.assert_array_equal(h5fp['volume'][10:16], data_partial)
             # Check that the rest of the data are zero
-            self.assertFalse(np.any(h5fp['volume'][:10]))
-            self.assertFalse(np.any(h5fp['volume'][16:]))
+            self.assertTrue(np.all(np.isnan(h5fp['volume'][:10])))
+            self.assertTrue(np.all(np.isnan(h5fp['volume'][16:])))
     
     def test_write_hdf5_full_overwrite(self):
         # Create some existing data to overwrite
@@ -153,8 +153,8 @@ class WriteHDF5Tests(unittest.TestCase):
             # Check that the target data were saved in the right place
             np.testing.assert_array_equal(h5fp['volume'][10:16], data_partial)
             # Check that the rest of the data are zero
-            self.assertFalse(np.any(h5fp['volume'][:10]))
-            self.assertFalse(np.any(h5fp['volume'][16:]))
+            self.assertTrue(np.all(np.isnan(h5fp['volume'][:10])))
+            self.assertTrue(np.all(np.isnan(h5fp['volume'][16:])))
     
     def test_write_hdf5_partial_overwrite(self):
         # Create some existing data to overwrite
@@ -174,9 +174,9 @@ class WriteHDF5Tests(unittest.TestCase):
             self.assertIn('volume', h5fp)
             # Check that the target data were saved in the right place
             np.testing.assert_array_equal(h5fp['volume'][10:16], data_partial)
-            # Check that the rest of the data are zero
-            self.assertFalse(np.any(h5fp['volume'][:10]))
-            self.assertFalse(np.any(h5fp['volume'][16:]))
+            # Check that the rest of the data are np.nan
+            self.assertTrue(np.all(np.isnan(h5fp['volume'][:10])))
+            self.assertTrue(np.all(np.isnan(h5fp['volume'][16:])))
     
     def test_write_hdf5_mismatched_dtypes(self):
         """Try to write partial data with mismatch dtypes should fail."""

--- a/tests/test_file_io.py
+++ b/tests/test_file_io.py
@@ -105,3 +105,87 @@ class ReadParamTests(unittest.TestCase):
         self.assertEqual(params.filter_1_thickness, 0.)
         self.assertEqual(params.filter_2_material, 'Al')
         self.assertEqual(params.filter_2_thickness, 0.)
+
+
+class WriteHDF5Tests(unittest.TestCase):
+    hdf_filename = 'test_output.h5'
+    
+    def tearDown(self):
+        if os.path.exists(self.hdf_filename):
+            os.remove(self.hdf_filename)
+    
+    def test_write_hdf5_full(self):
+        data = phantom.shepp3d(size=32, dtype='float16')
+        file_io.write_hdf5(data, fname=self.hdf_filename)
+        # Check that the data were written properly
+        with h5py.File(self.hdf_filename, mode='r') as h5fp:
+            self.assertIn('volume', h5fp)
+            np.testing.assert_array_equal(h5fp['volume'], data)
+    
+    def test_write_hdf5_partial(self):
+        data = phantom.shepp3d(size=32, dtype='float16')
+        data_partial = data[10:16]
+        # Write the data to the HDF5 file
+        file_io.write_hdf5(data_partial, fname=self.hdf_filename, maxsize=data.shape, dest_idx=slice(10,16))
+        # Check that the data were written properly
+        with h5py.File(self.hdf_filename, mode='r') as h5fp:
+            self.assertIn('volume', h5fp)
+            # Check that the target data were saved in the right place
+            np.testing.assert_array_equal(h5fp['volume'][10:16], data_partial)
+            # Check that the rest of the data are zero
+            self.assertFalse(np.any(h5fp['volume'][:10]))
+            self.assertFalse(np.any(h5fp['volume'][16:]))
+    
+    def test_write_hdf5_full_overwrite(self):
+        # Create some existing data to overwrite
+        with h5py.File(self.hdf_filename, mode='a') as h5fp:
+            h5fp.create_dataset('volume', data=np.empty((8, 8, 8)))
+        # Create a dummy dataset to reconstruct
+        data = phantom.shepp3d(size=32, dtype='float16')
+        data_partial = data[10:16]
+        # Write the data to the HDF5 file
+        file_io.write_hdf5(data_partial, fname=self.hdf_filename,
+                           maxsize=data.shape, dest_idx=slice(10,16),
+                           overwrite=True)
+        # Check that the data were written properly
+        with h5py.File(self.hdf_filename, mode='r') as h5fp:
+            self.assertIn('volume', h5fp)
+            # Check that the target data were saved in the right place
+            np.testing.assert_array_equal(h5fp['volume'][10:16], data_partial)
+            # Check that the rest of the data are zero
+            self.assertFalse(np.any(h5fp['volume'][:10]))
+            self.assertFalse(np.any(h5fp['volume'][16:]))
+    
+    def test_write_hdf5_partial_overwrite(self):
+        # Create some existing data to overwrite
+        with h5py.File(self.hdf_filename, mode='a') as h5fp:
+            h5fp.create_dataset('volume', data=np.ones((8, 8, 8)))
+        data = phantom.shepp3d(size=32, dtype='float32')
+        data_partial = data[10:16]
+        data_partial_a = data[10:13]
+        data_partial_b = data[13:16]
+        # Write the data to the HDF5 file
+        file_io.write_hdf5(data_partial_a, fname=self.hdf_filename,
+                           maxsize=data.shape, dest_idx=slice(10,13), overwrite=True)
+        file_io.write_hdf5(data_partial_b, fname=self.hdf_filename,
+                           maxsize=data.shape, dest_idx=slice(13,16), overwrite=False)
+        # Check that the data were written properly
+        with h5py.File(self.hdf_filename, mode='r') as h5fp:
+            self.assertIn('volume', h5fp)
+            # Check that the target data were saved in the right place
+            np.testing.assert_array_equal(h5fp['volume'][10:16], data_partial)
+            # Check that the rest of the data are zero
+            self.assertFalse(np.any(h5fp['volume'][:10]))
+            self.assertFalse(np.any(h5fp['volume'][16:]))
+    
+    def test_write_hdf5_mismatched_dtypes(self):
+        """Try to write partial data with mismatch dtypes should fail."""
+        # Create some existing data to overwrite
+        with h5py.File(self.hdf_filename, mode='a') as h5fp:
+            h5fp.create_dataset('volume', data=np.ones((8, 8, 8)))
+        data = phantom.shepp3d(size=8, dtype='float32')
+        # Write the data to the HDF5 file
+        with self.assertRaises(TypeError):
+            file_io.write_hdf5(data[10:13], fname=self.hdf_filename,
+                               maxsize=data.shape, dest_idx=slice(10,13),
+                               overwrite=False, dtype='int')

--- a/tests/test_recon.py
+++ b/tests/test_recon.py
@@ -1,0 +1,47 @@
+from unittest import TestCase, mock
+import os
+
+import numpy as np
+import h5py
+
+import tomopy
+from tomopy_cli.recon import rec
+
+
+HDF_FILE = './test_tomogram.h5'
+
+
+def make_params():
+    params = mock.MagicMock()
+    params.file_name = HDF_FILE
+    params.rotation_axis = 32
+    params.file_type = 'standard'
+    params.file_format = 'dx'
+    params.flat_correction_method = 'standard'
+    params.reconstruction_algorithm = 'gridrec'
+    params.gridrec_filter = 'parzen'
+    params.reconstruction_mask_ratio = 1.0
+    params.reconstruction_type = 'slice'
+    return params
+
+
+class ReconTests(TestCase):
+    def setUp(self):
+        # Prepare some dummy data
+        phantom = tomopy.misc.phantom.shepp3d(size=64)
+        phantom = np.exp(-phantom)
+        flat = np.ones((2, *phantom.shape[1:]))
+        dark = np.zeros((2, *phantom.shape[1:]))
+        with h5py.File(HDF_FILE, mode='w-') as fp:
+            fp.create_dataset('/exchange/data', data=phantom)
+            fp.create_dataset('/exchange/data_white', data=flat)
+            fp.create_dataset('/exchange/data_dark', data=dark)
+    
+    def tearDown(self):
+        if os.path.exists(HDF_FILE):
+            os.remove(HDF_FILE)
+        
+    def test_basic_reconstruction(self):
+        params = make_params()
+        params.reconstruction_type = 'slice'
+        response = rec(params=params)

--- a/tests/test_recon.py
+++ b/tests/test_recon.py
@@ -1,5 +1,7 @@
 from unittest import TestCase, mock
 import os
+import shutil
+from pathlib import Path
 
 import numpy as np
 import h5py
@@ -7,13 +9,12 @@ import h5py
 import tomopy
 from tomopy_cli.recon import rec
 
-
-HDF_FILE = './test_tomogram.h5'
+HDF_FILE = Path(__file__).resolve().parent / 'test_tomogram.h5'
 
 
 def make_params():
     params = mock.MagicMock()
-    params.file_name = HDF_FILE
+    params.file_name = str(HDF_FILE)
     params.rotation_axis = 32
     params.file_type = 'standard'
     params.file_format = 'dx'
@@ -26,22 +27,30 @@ def make_params():
 
 
 class ReconTests(TestCase):
+    output_dir = Path(__file__).resolve().parent.parent / 'tests_rec'
+
     def setUp(self):
         # Prepare some dummy data
         phantom = tomopy.misc.phantom.shepp3d(size=64)
         phantom = np.exp(-phantom)
         flat = np.ones((2, *phantom.shape[1:]))
         dark = np.zeros((2, *phantom.shape[1:]))
-        with h5py.File(HDF_FILE, mode='w-') as fp:
+        with h5py.File(str(HDF_FILE), mode='w-') as fp:
             fp.create_dataset('/exchange/data', data=phantom)
             fp.create_dataset('/exchange/data_white', data=flat)
             fp.create_dataset('/exchange/data_dark', data=dark)
     
     def tearDown(self):
-        if os.path.exists(HDF_FILE):
-            os.remove(HDF_FILE)
+        # Remove the temporary HDF5 file
+        if os.path.exists(str(HDF_FILE)):
+            os.remove(str(HDF_FILE))
+        # Remove the reconstructed output
+        if self.output_dir.exists():
+            shutil.rmtree(self.output_dir)
         
     def test_basic_reconstruction(self):
+        """Check that a basic reconstruction completes and produces output tiff files."""
         params = make_params()
         params.reconstruction_type = 'slice'
         response = rec(params=params)
+        self.assertTrue(self.output_dir.exists())

--- a/tomopy_cli/config.py
+++ b/tomopy_cli/config.py
@@ -346,7 +346,13 @@ SECTIONS['reconstruction'] = {
         'default': 1.0,
         'type': float,
         'help': "Ratio of the mask’s diameter in pixels to the smallest edge size along given axis"},
-        }
+    'output-format': {
+        'default': 'tiff_stack',
+        'type': str,
+        'help': "How to save the reconstructed data. Only applies when ``reconstruction-type == 'full'``.",
+        'choices': ['tiff_stack', 'hdf5'],
+        },
+    }
 
 SECTIONS['gridrec'] = {
     'gridrec-filter': {

--- a/tomopy_cli/file_io.py
+++ b/tomopy_cli/file_io.py
@@ -233,7 +233,6 @@ def get_dx_dims(params):
     dataset='data'
 
     grp = '/'.join(['exchange', dataset])
-    print(params.file_name)
     with h5py.File(params.file_name, "r") as f:
         try:
             data = f[grp]

--- a/tomopy_cli/file_io.py
+++ b/tomopy_cli/file_io.py
@@ -92,14 +92,14 @@ def _read_tomo(params, sino):
     if (str(params.file_format) in {'dx', 'aps2bm', 'aps7bm', 'aps32id'}):
         proj, flat, dark, theta = dxchange.read_aps_32id(params.file_name, sino=sino)
         log.info("  *** %s is a valid dx file format" % params.file_name)
-        #Check if the flat and dark fields are single images or sets
+        # Check if the flat and dark fields are single images or sets
         if len(flat.shape) == len(proj.shape):
             log.info('  *** median filter flat images')
-            #Do a median filter on the first dimension
+            # Do a median filter on the first dimension
             flat = np.median(flat, axis=0, keepdims=True).astype(flat.dtype) 
         if len(dark.shape) == len(proj.shape):
             log.info('  *** median filter dark images')
-            #Do a median filter on the first dimension
+            # Do a median filter on the first dimension
             dark = np.median(dark, axis=0, keepdims=True).astype(dark.dtype) 
     else:
         log.error("  *** %s is not a supported file format" % params.file_format)
@@ -233,7 +233,7 @@ def get_dx_dims(params):
     dataset='data'
 
     grp = '/'.join(['exchange', dataset])
-
+    print(params.file_name)
     with h5py.File(params.file_name, "r") as f:
         try:
             data = f[grp]

--- a/tomopy_cli/file_io.py
+++ b/tomopy_cli/file_io.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 import h5py
 import json
 import collections
@@ -555,6 +556,8 @@ def write_hdf5(data, fname, dname='volume', dtype=None,
         dtype = data.dtype
     if dest_idx is None:
         dest_idx = ()
+    # Create parent directory if necessary
+    Path(fname).parent.mkdir(parents=True, exist_ok=True)
     # Open the HDF5 file so we can save data to it
     with h5py.File(fname, mode='a') as h5fp:
         # Delete the dataset if it already exists and is being overwritten
@@ -562,7 +565,7 @@ def write_hdf5(data, fname, dname='volume', dtype=None,
             del h5fp[dname]
         # Create a new dataset if necessary
         try:
-            ds = h5fp.require_dataset(dname, shape=maxsize, dtype=dtype, fillvalue=0, exact=True)
+            ds = h5fp.require_dataset(dname, shape=maxsize, dtype=dtype, fillvalue=np.nan, exact=True)
         except TypeError as e:
             msg = str(e) + ". Use *overwrite=True* to overwrite existing dataset."
             raise type(e)(msg)

--- a/tomopy_cli/prep.py
+++ b/tomopy_cli/prep.py
@@ -7,6 +7,7 @@ import numpy as np
 from tomopy_cli import log
 from tomopy_cli import file_io
 from tomopy_cli import beamhardening
+from tomopy_cli import config
 
 def all(proj, flat, dark, params, sino):
     # zinger_removal
@@ -82,7 +83,11 @@ def flat_correction(proj, flat, dark, params):
     elif(params.flat_correction_method == 'none'):
         data = proj
         log.warning('  *** *** normalization is turned off')
-    #data[data < 1e-4] = 1e-4
+    else:
+        raise ValueError("Unknown value for *flat_correction_method*: {}. "
+                         "Valid options are {}"
+                         "".format(params.flat_correction_method,
+                                   config.SECTIONS['flat-correction']['flat-correction-method']['choices']))
     return data
 
 

--- a/tomopy_cli/recon.py
+++ b/tomopy_cli/recon.py
@@ -39,7 +39,7 @@ def rec(params):
         if params.nsino_per_chunk < 1:
             params.nsino_per_chunk = cpu_count()
         nSino_per_chunk = params.nsino_per_chunk * pow(2, int(params.binning))
-        chunks = int(np.ceil((sino_end - sino_start)/nSino_per_chunk))    
+        chunks = int(np.ceil((sino_end - sino_start)/nSino_per_chunk))
     elif (params.reconstruction_type == 'try'):
         _try_rec(params)
         return
@@ -50,11 +50,16 @@ def rec(params):
         sino_start = ssino
         sino_end = sino_start + pow(2, int(params.binning)) 
 
-    log.info("reconstructing [%d] slices from slice [%d] to [%d] in [%d] chunks of [%d] slices each" % \
+    log.info("  *** reconstructing [%d] slices from slice [%d] to [%d] in [%d] chunks of [%d] slices each" % \
                ((sino_end - sino_start)/pow(2, int(params.binning)), sino_start/pow(2, int(params.binning)), sino_end/pow(2, int(params.binning)), \
                chunks, nSino_per_chunk/pow(2, int(params.binning))))            
 
     strt = sino_start
+    write_threads = []
+    if chunks == 0:
+        log.warning("  *** 0 chunks selected for reconstruction, check your *start_row*, "
+                    "*end_row*, and *nsino_per_chunk*.")
+    print(chunks)
     for iChunk in range(0, chunks):
         log.info('chunk # %i/%i' % (iChunk + 1, chunks))
         sino_chunk_start = np.int(sino_start + nSino_per_chunk*iChunk)
@@ -65,7 +70,6 @@ def rec(params):
         log.info('  *** [%i, %i]' % (sino_chunk_start/pow(2, int(params.binning)), sino_chunk_end/pow(2, int(params.binning))))
                 
         sino = np.array((int(sino_chunk_start), int(sino_chunk_end)))
-        
         phase_pad = params.retrieve_phase_pad
         # extra data for padded phase retrieval
         if params.retrieve_phase_method == "paganin":
@@ -77,12 +81,11 @@ def rec(params):
         proj, flat, dark, theta, rotation_axis = file_io.read_tomo(sino, params)
         # What if sino overruns the size of data?
         if sino[1] - sino[0] > proj.shape[1]:
-            log.warning(" *** Chunk size > remaining data size.")
+            log.warning("  *** Chunk size > remaining data size.")
             sino = (sino[0], sino[0] + proj.shape[1])
 
         # apply all preprocessing functions
         data = prep.all(proj, flat, dark, params, sino)
-
         # unpad after phase retrieval
         if params.retrieve_phase_method == "paganin":
                 data = data[:,(iChunk>0)*phase_pad:-(iChunk<chunks-1)*phase_pad-(phase_pad==0)]
@@ -94,12 +97,24 @@ def rec(params):
         rec = padded_rec(data, theta, rotation_axis, params)
         # Save images
         if params.reconstruction_type == "full":
-            tail = os.sep + os.path.splitext(os.path.basename(params.file_name))[0]+ '_rec' + os.sep 
-            fname = os.path.dirname(params.file_name) + '_rec' + tail + 'recon'
-            write_thread = threading.Thread(target=dxchange.write_tiff_stack,
-                                            args = (rec,),
-                                            kwargs = {'fname':fname, 'start':strt, 'overwrite':True})
+            recon_base_dir = os.path.dirname(params.file_name) + '_rec'
+            tail = os.path.splitext(os.path.basename(params.file_name))[0]+ '_rec'
+            if params.output_format == 'tiff':
+                fname = os.path.join(recon_base_dir, tail, 'recon')
+                print(f"Full tiff dir: {fname}")
+                write_thread = threading.Thread(target=dxchange.write_tiff_stack,
+                                                args = (rec,),
+                                                kwargs = {'fname':fname, 'start':strt, 'overwrite':True})
+            else:
+                fname = os.path.join(recon_base_dir, tail + '.hdf5')
+                write_thread = threading.Thread(target=file_io.write_hdf5,
+                                                args = (rec,),
+                                                kwargs = {'fname':fname,
+                                                          'dest_idx': slice(strt, strt+rec.shape[0]),
+                                                          'maxsize': (sino_end, *rec.shape[1:]),
+                                                          'overwrite': iChunk==0})
             write_thread.start()
+            write_threads.append(write_thread)
             strt += int((sino[1] - sino[0]) / np.power(2, float(params.binning)))
         elif params.reconstruction_type == "slice":
             fname = Path.joinpath(Path(os.path.dirname(os.path.abspath(params.file_name)) + '_rec'),
@@ -111,7 +126,9 @@ def rec(params):
                              "".format(params.reconstruction_type,
                                        config.SECTIONS['reconstruction']['reconstruction-type']['choices']))
         log.info("  *** reconstructions: %s" % fname)
-    
+    # Wait until the all threads are done writing data
+    for thread in write_threads:
+        thread.join()
 
 def _try_rec(params):
     log.info("  *** *** starting 'try' reconstruction") 

--- a/tomopy_cli/recon.py
+++ b/tomopy_cli/recon.py
@@ -102,7 +102,7 @@ def rec(params):
             write_thread.start()
             strt += int((sino[1] - sino[0]) / np.power(2, float(params.binning)))
         elif params.reconstruction_type == "slice":
-            fname = Path.joinpath(Path(os.path.dirname(params.file_name) + '_rec'), 
+            fname = Path.joinpath(Path(os.path.dirname(os.path.abspath(params.file_name)) + '_rec'),
                                     'slice_rec', 'recon_'+ Path(params.file_name).stem)
             dxchange.write_tiff_stack(rec, fname=str(fname), overwrite=False)
         else:

--- a/tomopy_cli/recon.py
+++ b/tomopy_cli/recon.py
@@ -10,6 +10,7 @@ import dxchange
 
 from tomopy_cli import log
 from tomopy_cli import file_io
+from tomopy_cli import config
 from tomopy_cli import prep
 from tomopy_cli import beamhardening
 from tomopy_cli import find_center
@@ -67,7 +68,7 @@ def rec(params):
         
         phase_pad = params.retrieve_phase_pad
         # extra data for padded phase retrieval
-        if(params.retrieve_phase_method=="paganin"):
+        if params.retrieve_phase_method == "paganin":
                 sino[0] -= (iChunk>0)*phase_pad
                 sino[1] += (iChunk<chunks-1)*phase_pad
                 log.info('  *** extra padding for phase retrieval gives slices [%i,%i] ' % (sino[0],sino[1]))
@@ -83,7 +84,7 @@ def rec(params):
         data = prep.all(proj, flat, dark, params, sino)
 
         # unpad after phase retrieval
-        if(params.retrieve_phase_method=="paganin"):
+        if params.retrieve_phase_method == "paganin":
                 data = data[:,(iChunk>0)*phase_pad:-(iChunk<chunks-1)*phase_pad-(phase_pad==0)]
                 sino[0] += (iChunk>0)*phase_pad
                 sino[1] -= (iChunk<chunks-1)*phase_pad
@@ -92,7 +93,7 @@ def rec(params):
         # Reconstruct: this is for "slice" and "full" methods
         rec = padded_rec(data, theta, rotation_axis, params)
         # Save images
-        if (params.reconstruction_type == "full"):
+        if params.reconstruction_type == "full":
             tail = os.sep + os.path.splitext(os.path.basename(params.file_name))[0]+ '_rec' + os.sep 
             fname = os.path.dirname(params.file_name) + '_rec' + tail + 'recon'
             write_thread = threading.Thread(target=dxchange.write_tiff_stack,
@@ -100,11 +101,15 @@ def rec(params):
                                             kwargs = {'fname':fname, 'start':strt, 'overwrite':True})
             write_thread.start()
             strt += int((sino[1] - sino[0]) / np.power(2, float(params.binning)))
-        if (params.reconstruction_type == "slice"):
+        elif params.reconstruction_type == "slice":
             fname = Path.joinpath(Path(os.path.dirname(params.file_name) + '_rec'), 
                                     'slice_rec', 'recon_'+ Path(params.file_name).stem)
             dxchange.write_tiff_stack(rec, fname=str(fname), overwrite=False)
-
+        else:
+            raise ValueError("Unknown value for *reconstruction type*: {}. "
+                             "Valid options are {}"
+                             "".format(params.reconstruction_type,
+                                       config.SECTIONS['reconstruction']['reconstruction-type']['choices']))
         log.info("  *** reconstructions: %s" % fname)
     
 


### PR DESCRIPTION
 Added an option to save reconstruction to a tiff stack or HDF5 file.

config option *output_format* that can be either "tiff_stack" (default) or "hdf5"

Fixes: https://github.com/tomography/tomopy-cli/issues/51