### PR TITLE
Improved logging

### DIFF
--- a/bin/tomopy
+++ b/bin/tomopy
@@ -4,18 +4,20 @@ import os
 import re
 import sys
 import argparse
-import logging
 import time
 import pathlib
 from datetime import datetime
 
 from tomopy_cli import config, __version__
-from tomopy_cli import log
+from tomopy_cli import logging
 from tomopy_cli import recon
 from tomopy_cli import find_center
 from tomopy_cli import file_io
 from tomopy_cli import post
 from tomopy_cli.auto_complete import create_complete_tomopy
+
+
+log = logging.getLogger('tomopy_cli.bin.tomopy')
 
 
 def init(args):
@@ -154,8 +156,10 @@ def main():
         os.makedirs(logs_home)
 
     lfname = os.path.join(logs_home, 'tomopy_' + datetime.strftime(datetime.now(), "%Y-%m-%d_%H_%M_%S") + '.log')
- 
-    log.setup_custom_logger(lfname)
+
+    log_level = 'DEBUG' if args.verbose else "INFO"
+    logging.setup_custom_logger(lfname, level=log_level)
+    log.debug("Started tomopy_cli")
     log.info("Saving log at %s" % lfname)
 
     try:

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -12,15 +12,14 @@ from tomopy_cli import log as tplogging
 class LogFormattingTests(unittest.TestCase):
     temp_logfile = 'tests-temp.log'
     
-    def setUp(self):
-        self.log_capture = io.StringIO()
-        ch = logging.StreamHandler(self.log_capture)
-        tplogging.logger.addHandler(ch)
+    # def setUp(self):
+    #     self.log_capture = io.StringIO()
+
     
-    def tearDown(self):
-        # Remove temporary log files
-        if os.path.exists(self.temp_logfile):
-            os.remove(self.temp_logfile)
+    # def tearDown(self):
+    #     # Remove temporary log files
+    #     if os.path.exists(self.temp_logfile):
+    #         os.remove(self.temp_logfile)
     
     def test_setup_custom_logger(self):
         """Verify that setting up a custom logger produces formatted output."""
@@ -28,11 +27,11 @@ class LogFormattingTests(unittest.TestCase):
         stderr_io = io.StringIO()
         old_stderr = sys.stderr
         sys.stderr = stderr_io
-        # Do some logging both with and without setting up custom logger
         try:
-            tplogging.warning("No danger, Will Robinson")
+            # Do some logging after setting up custom logger
+            logger = logging.getLogger('tomopy_cli.fancy_logger')
             tplogging.setup_custom_logger(lfname=None)
-            tplogging.warning("Formatted danger, Will Robinson")
+            logger.warning("Formatted danger, Will Robinson")
         finally:
             # Restore stderr
             sys.stderr = old_stderr
@@ -40,13 +39,13 @@ class LogFormattingTests(unittest.TestCase):
         stderr_io.seek(0)
         loglines = stderr_io.readlines()
         self.assertEqual(len(loglines), 1)
-        self.assertNotIn("No danger", loglines[0])
         self.assertIn("\x1b[33m", loglines[0])
         self.assertIn("\x1b[0m", loglines[0])
     
     def test_colored_log_formatter(self):
+        log_capture = io.StringIO()
         # Logging without colored formatting
-        ch = logging.StreamHandler(self.log_capture)
+        ch = logging.StreamHandler(log_capture)
         logger = logging.getLogger('_test_logger')
         logger.addHandler(ch)
         logger.warning("Danger, Will Robinson")
@@ -54,8 +53,8 @@ class LogFormattingTests(unittest.TestCase):
         ch.setFormatter(tplogging.ColoredLogFormatter('%(asctime)s - %(message)s'))
         logger.warning("Formatted danger, Will Robinson")
         # Check the logged output for formatting
-        self.log_capture.seek(0)
-        loglines = self.log_capture.readlines()
+        log_capture.seek(0)
+        loglines = log_capture.readlines()
         self.assertNotIn("\x1b[33m", loglines[0])
         self.assertNotIn("\x1b[0m", loglines[0])
         self.assertIn("\x1b[33m", loglines[1])

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,62 @@
+import unittest
+import io
+import logging
+import sys
+import os
+
+from tomopy_cli import log as tplogging
+
+
+# Set up variables to capture logging output
+
+class LogFormattingTests(unittest.TestCase):
+    temp_logfile = 'tests-temp.log'
+    
+    def setUp(self):
+        self.log_capture = io.StringIO()
+        ch = logging.StreamHandler(self.log_capture)
+        tplogging.logger.addHandler(ch)
+    
+    def tearDown(self):
+        # Remove temporary log files
+        if os.path.exists(self.temp_logfile):
+            os.remove(self.temp_logfile)
+    
+    def test_setup_custom_logger(self):
+        """Verify that setting up a custom logger produces formatted output."""
+        # Capture stderr to a string
+        stderr_io = io.StringIO()
+        old_stderr = sys.stderr
+        sys.stderr = stderr_io
+        # Do some logging both with and without setting up custom logger
+        try:
+            tplogging.warning("No danger, Will Robinson")
+            tplogging.setup_custom_logger(self.temp_logfile)
+            tplogging.warning("Formatted danger, Will Robinson")
+        finally:
+            # Restore stderr
+            sys.stderr = old_stderr
+        # Read the logged output to check for correctness
+        stderr_io.seek(0)
+        loglines = stderr_io.readlines()
+        self.assertEqual(len(loglines), 1)
+        self.assertNotIn("No danger", loglines[0])
+        self.assertIn("\x1b[33m", loglines[0])
+        self.assertIn("\x1b[0m", loglines[0])
+    
+    def test_colored_log_formatter(self):
+        # Logging without colored formatting
+        ch = logging.StreamHandler(self.log_capture)
+        logger = logging.getLogger('_test_logger')
+        logger.addHandler(ch)
+        logger.warning("Danger, Will Robinson")
+        # Logging with color formatting
+        ch.setFormatter(tplogging.ColoredLogFormatter('%(asctime)s - %(message)s'))
+        logger.warning("Formatted danger, Will Robinson")
+        # Check the logged output for formatting
+        self.log_capture.seek(0)
+        loglines = self.log_capture.readlines()
+        self.assertNotIn("\x1b[33m", loglines[0])
+        self.assertNotIn("\x1b[0m", loglines[0])
+        self.assertIn("\x1b[33m", loglines[1])
+        self.assertIn("\x1b[0m", loglines[1])

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -4,7 +4,7 @@ import logging
 import sys
 import os
 
-from tomopy_cli import log as tplogging
+from tomopy_cli import logging as tplogging
 
 
 # Set up variables to capture logging output
@@ -12,14 +12,27 @@ from tomopy_cli import log as tplogging
 class LogFormattingTests(unittest.TestCase):
     temp_logfile = 'tests-temp.log'
     
-    # def setUp(self):
-    #     self.log_capture = io.StringIO()
-
-    
-    # def tearDown(self):
-    #     # Remove temporary log files
-    #     if os.path.exists(self.temp_logfile):
-    #         os.remove(self.temp_logfile)
+    def test_setup_custom_logger_level(self):
+        """Verify that setting up a custom logger produces formatted output."""
+        # Capture stderr to a string
+        stderr_io = io.StringIO()
+        old_stderr = sys.stderr
+        sys.stderr = stderr_io
+        try:
+            # Do some logging after setting up custom logger
+            logger = logging.getLogger('tomopy_cli.fancy_logger')
+            tplogging.setup_custom_logger(lfname=None, level="INFO")
+            logger.debug("Debugging logs, Will Robinson")
+            logger.info("Information, Will Robinson")
+        finally:
+            # Restore stderr
+            sys.stderr = old_stderr
+        # Read the logged output to check for correctness
+        stderr_io.seek(0)
+        loglines = stderr_io.readlines()
+        self.assertEqual(len(loglines), 1)
+        self.assertIn("Information", loglines[0])
+        self.assertNotIn("Debugging", loglines[0])
     
     def test_setup_custom_logger(self):
         """Verify that setting up a custom logger produces formatted output."""

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -31,7 +31,7 @@ class LogFormattingTests(unittest.TestCase):
         # Do some logging both with and without setting up custom logger
         try:
             tplogging.warning("No danger, Will Robinson")
-            tplogging.setup_custom_logger(self.temp_logfile)
+            tplogging.setup_custom_logger(lfname=None)
             tplogging.warning("Formatted danger, Will Robinson")
         finally:
             # Restore stderr

--- a/tomopy_cli/auto_complete/create_complete_tomopy.py
+++ b/tomopy_cli/auto_complete/create_complete_tomopy.py
@@ -1,5 +1,9 @@
+import logging
 import subprocess
-from tomopy_cli import log
+
+
+log = logging.getLogger(__name__)
+
 
 def run(fname):
     try:

--- a/tomopy_cli/beamhardening.py
+++ b/tomopy_cli/beamhardening.py
@@ -52,6 +52,7 @@ Usage:
 from copy import deepcopy
 import os
 from pathlib import Path, PurePath
+import logging
 
 import numpy as np
 import scipy.interpolate
@@ -62,8 +63,11 @@ from scipy.signal import convolve
 from scipy.signal.windows import gaussian
 
 from tomopy.util import mproc
-from tomopy_cli import log
 from tomopy_cli import config
+
+
+logging.getLogger(__name__)
+
 
 #Global variables we need for computing LUT
 filters = {}

--- a/tomopy_cli/config.py
+++ b/tomopy_cli/config.py
@@ -513,10 +513,8 @@ def parse_known_args(parser, subparser=False):
         subparser_value = [sys.argv[1]] if subparser else []
         config_values = config_to_list(config_name=get_config_name())
         values = subparser_value + config_values + sys.argv[1:]
-        #print(subparser_value, config_values, values)
     else:
-        values = ""
-
+        raise TypeError("A command is required. See ``tomopy --help`` for detailed usage.")
     return parser.parse_known_args(values)[0]
 
 

--- a/tomopy_cli/config.py
+++ b/tomopy_cli/config.py
@@ -4,14 +4,18 @@ import shutil
 import pathlib
 import argparse
 import configparser
+from collections import OrderedDict
+import logging
+
 import h5py
 import numpy as np
 
-from collections import OrderedDict
-
-from tomopy_cli import log
 from tomopy_cli import util
 from tomopy_cli import __version__
+
+
+log = logging.getLogger(__name__)
+
 
 LOGS_HOME = os.path.join(str(pathlib.Path.home()), 'logs')
 CONFIG_FILE_NAME = os.path.join(str(pathlib.Path.home()), 'tomopy.conf')
@@ -662,8 +666,8 @@ def write_hdf(args=None, sections=None):
                         try:
                             hdf_file[dataset][0] = np.string_(str(value))
                         except TypeError:
-                            print(value)
-                            raise TypeError
+                            log.error("Could not convert value {}".format(value))
+                            raise
 
 
 def log_values(args):

--- a/tomopy_cli/file_io.py
+++ b/tomopy_cli/file_io.py
@@ -1,16 +1,17 @@
 import os
+import logging
 from pathlib import Path
-import h5py
 import json
 import collections
 import re
+
+import h5py
 import tomopy
 import dxchange
 import dxchange.reader as dxreader
 import dxfile.dxtomo as dx
 import numpy as np
 
-from tomopy_cli import log
 from tomopy_cli import __version__
 from tomopy_cli import find_center
 from tomopy_cli import config
@@ -20,8 +21,10 @@ __author__ = "Francesco De Carlo, Viktor Nikitin, Alan Kastengren"
 __credits__ = "Pavel Shevchenko"
 __copyright__ = "Copyright (c) 2020, UChicago Argonne, LLC."
 __docformat__ = 'restructuredtext en'
-__all__ = ['read_tomo',
-           ]
+__all__ = ['read_tomo',]
+
+
+log = logging.getLogger(__name__)
 
 
 def read_tomo(sino, params, ignore_flip = False):

--- a/tomopy_cli/find_center.py
+++ b/tomopy_cli/find_center.py
@@ -1,15 +1,19 @@
 import os
 import json
+import logging
+
 import tomopy
 import numpy as np
 import h5py
 from skimage.filters import gaussian
 import skimage.feature
 
-from tomopy_cli import log
 from tomopy_cli import prep
 from tomopy_cli import config
 from tomopy_cli import file_io
+
+
+log = logging.getLogger(__name__)
 
 
 def find_rotation_axis(params):

--- a/tomopy_cli/log.py
+++ b/tomopy_cli/log.py
@@ -1,27 +1,57 @@
-'''
-Customized logging for the tomopy_cli library.
+'''Customized logging for the tomopy_cli library.
+
+Logging in tomopy_cli is built upon the standard logging functionality
+in python. This module provides a ``getLogger`` module that can be
+used to get a logger object with the usual *debug*, *info*, etc.,
+methods. If ``setup_custom_logger`` is called, all subsequent calls to
+``getLogger`` will produce a logger that reflects these
+customizations.
 
 '''
 import logging
+import warnings
 
 
 logger = logging.getLogger(__name__)
 
 
+def old_logging(func):
+    def inside(*args, **kwargs):
+        warnings.warn(
+            "``tomopy_cli.log.{}`` is deprecated, use the python logging module directly."
+            "".format(str(func)[10:17]),
+            DeprecationWarning,
+        )
+        return func(*args, **kwargs)
+    return inside
+
+
+@old_logging
+def debug(msg):
+    logger.debug(msg)
+
+
+@old_logging
 def info(msg):
     logger.info(msg)
 
 
+@old_logging
 def error(msg):
     logger.error(msg)
 
 
+@old_logging
 def warning(msg):
     logger.warning(msg)
 
 
-def setup_custom_logger(lfname: str=None, stream_to_console: bool=True):
+def setup_custom_logger(lfname: str=None, stream_to_console: bool=True, level=logging.DEBUG):
     """Prepare the logging system with custom formatting.
+    
+    This adds handlers to the *tomopy_cli* parent logger. Any logger
+    inside tomopy_cli will produce output based on this functions
+    customization parameters.
     
     Parameters
     ----------
@@ -31,33 +61,50 @@ def setup_custom_logger(lfname: str=None, stream_to_console: bool=True):
     stream_to_console
       If true, logs will be output to the console with color
       formatting.
+    level
+      A logging level for the handler. This can be either a string
+      ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"), or an actual
+      level defined in the python logging framework.
     
     """
+    parent_name = __name__.split('.')[0]  # Nominally "tomopy_cli"
+    parent_logger = logging.getLogger(parent_name)
+    parent_logger.setLevel(level)
+    # Set up normal output to a file
     if lfname is not None:
         fHandler = logging.FileHandler(lfname)
-        logger.setLevel(logging.DEBUG)
-        file_formatter = logging.Formatter('%(asctime)s - %(levelname)s: %(message)s')
+        file_formatter = logging.Formatter('%(asctime)s - %(name)s(%(lineno)s) - %(levelname)s: %(message)s')
         fHandler.setFormatter(file_formatter)
-        logger.addHandler(fHandler)
+        parent_logger.addHandler(fHandler)
+    # Set up formatted output to the console
     if stream_to_console:
         ch = logging.StreamHandler()
         ch.setFormatter(ColoredLogFormatter('%(asctime)s - %(message)s'))
-        ch.setLevel(logging.DEBUG)
-        logger.addHandler(ch)
+        parent_logger.addHandler(ch)
 
 
 class ColoredLogFormatter(logging.Formatter):
     """A logging formatter that add console color codes."""
+    __BLUE = '\033[94m'
     __GREEN = '\033[92m'
     __RED = '\033[91m'
+    __RED_BG = '\033[41m'
     __YELLOW = '\033[33m'
     __ENDC = '\033[0m'
     
+    def _format_message_level(self, message, level):
+        colors = {
+            'INFO': self.__GREEN,
+            'WARNING': self.__YELLOW,
+            'ERROR': self.__RED,
+            'CRITICAL': self.__RED_BG,
+        }
+        if level in colors.keys():
+            message = "{color}{message}{ending}".format(color=colors[level],
+                                                        message=message,
+                                                        ending=self.__ENDC)
+        return message
+    
     def formatMessage(self, record):
-        if record.levelname=='INFO':
-            record.message = self.__GREEN + record.message + self.__ENDC
-        elif record.levelname == 'WARNING':
-            record.message = self.__YELLOW + record.message + self.__ENDC
-        elif record.levelname == 'ERROR':
-            record.message = self.__RED + record.message + self.__ENDC
+        record.message = self._format_message_level(record.message, record.levelname)
         return super().formatMessage(record)

--- a/tomopy_cli/log.py
+++ b/tomopy_cli/log.py
@@ -1,43 +1,59 @@
 '''
-    Log Lib for Sector 2-BM 
-    
+Customized logging for the tomopy_cli library.
+
 '''
 import logging
 
+
 logger = logging.getLogger(__name__)
+
 
 def info(msg):
     logger.info(msg)
 
+
 def error(msg):
     logger.error(msg)
+
 
 def warning(msg):
     logger.warning(msg)
 
-def setup_custom_logger(lfname, stream_to_console=True):
-    fHandler = logging.FileHandler(lfname)
-    logger.setLevel(logging.DEBUG)
-    file_formatter = logging.Formatter('%(asctime)s - %(levelname)s: %(message)s')
-    fHandler.setFormatter(file_formatter)
-    logger.addHandler(fHandler)
+
+def setup_custom_logger(lfname: str=None, stream_to_console: bool=True):
+    """Prepare the logging system with custom formatting.
+    
+    Parameters
+    ----------
+    lfname
+      Path to where the log file should be stored. If omitted, no file
+      logging will be performed.
+    stream_to_console
+      If true, logs will be output to the console with color
+      formatting.
+    
+    """
+    if lfname is not None:
+        fHandler = logging.FileHandler(lfname)
+        logger.setLevel(logging.DEBUG)
+        file_formatter = logging.Formatter('%(asctime)s - %(levelname)s: %(message)s')
+        fHandler.setFormatter(file_formatter)
+        logger.addHandler(fHandler)
     if stream_to_console:
         ch = logging.StreamHandler()
         ch.setFormatter(ColoredLogFormatter('%(asctime)s - %(message)s'))
         ch.setLevel(logging.DEBUG)
         logger.addHandler(ch)
 
+
 class ColoredLogFormatter(logging.Formatter):
-    def __init__(self, fmt, datefmt=None, style='%'):
-        # Logging defines
-        self.__GREEN = "\033[92m"
-        self.__RED = '\033[91m'
-        self.__YELLOW = '\033[33m'
-        self.__ENDC = '\033[0m'
-        super().__init__(fmt, datefmt, style)
+    """A logging formatter that add console color codes."""
+    __GREEN = '\033[92m'
+    __RED = '\033[91m'
+    __YELLOW = '\033[33m'
+    __ENDC = '\033[0m'
     
-    
-    def formatMessage(self,record):
+    def formatMessage(self, record):
         if record.levelname=='INFO':
             record.message = self.__GREEN + record.message + self.__ENDC
         elif record.levelname == 'WARNING':

--- a/tomopy_cli/logging.py
+++ b/tomopy_cli/logging.py
@@ -1,49 +1,18 @@
 '''Customized logging for the tomopy_cli library.
 
 Logging in tomopy_cli is built upon the standard logging functionality
-in python. This module provides a ``getLogger`` module that can be
-used to get a logger object with the usual *debug*, *info*, etc.,
-methods. If ``setup_custom_logger`` is called, all subsequent calls to
-``getLogger`` will produce a logger that reflects these
-customizations.
+in python. This module provides the standard ``getLogger`` function
+that can be used to get a logger object with the usual *debug*,
+*info*, etc., methods. If ``setup_custom_logger`` is called, all
+``tomopy_cli.*`` loggers will use color terminal logging and/or a
+logfile.
 
 '''
 import logging
-import warnings
+from logging import *
 
 
-logger = logging.getLogger(__name__)
-
-
-def old_logging(func):
-    def inside(*args, **kwargs):
-        warnings.warn(
-            "``tomopy_cli.log.{}`` is deprecated, use the python logging module directly."
-            "".format(str(func)[10:17]),
-            DeprecationWarning,
-        )
-        return func(*args, **kwargs)
-    return inside
-
-
-@old_logging
-def debug(msg):
-    logger.debug(msg)
-
-
-@old_logging
-def info(msg):
-    logger.info(msg)
-
-
-@old_logging
-def error(msg):
-    logger.error(msg)
-
-
-@old_logging
-def warning(msg):
-    logger.warning(msg)
+__all__ = ['setup_custom_logger', 'ColoredLogFormatter'] + logging.__all__
 
 
 def setup_custom_logger(lfname: str=None, stream_to_console: bool=True, level=logging.DEBUG):
@@ -51,7 +20,9 @@ def setup_custom_logger(lfname: str=None, stream_to_console: bool=True, level=lo
     
     This adds handlers to the *tomopy_cli* parent logger. Any logger
     inside tomopy_cli will produce output based on this functions
-    customization parameters.
+    customization parameters. The file given in *lfname* will receive
+    all log message levels, while the console will receive messages
+    based on *level*.
     
     Parameters
     ----------
@@ -62,24 +33,26 @@ def setup_custom_logger(lfname: str=None, stream_to_console: bool=True, level=lo
       If true, logs will be output to the console with color
       formatting.
     level
-      A logging level for the handler. This can be either a string
-      ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"), or an actual
-      level defined in the python logging framework.
-    
+      A logging level for the stream handler. This can be either a
+      string ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"), or an
+      actual level defined in the python logging framework.
+
     """
     parent_name = __name__.split('.')[0]  # Nominally "tomopy_cli"
     parent_logger = logging.getLogger(parent_name)
-    parent_logger.setLevel(level)
+    parent_logger.setLevel(logging.DEBUG)
     # Set up normal output to a file
     if lfname is not None:
         fHandler = logging.FileHandler(lfname)
         file_formatter = logging.Formatter('%(asctime)s - %(name)s(%(lineno)s) - %(levelname)s: %(message)s')
         fHandler.setFormatter(file_formatter)
+        fHandler.setLevel(logging.DEBUG)
         parent_logger.addHandler(fHandler)
     # Set up formatted output to the console
     if stream_to_console:
         ch = logging.StreamHandler()
         ch.setFormatter(ColoredLogFormatter('%(asctime)s - %(message)s'))
+        ch.setLevel(level)
         parent_logger.addHandler(ch)
 
 

--- a/tomopy_cli/post.py
+++ b/tomopy_cli/post.py
@@ -1,8 +1,11 @@
 import os
+import logging
+
 import tomopy
 import numpy as np
 
-from tomopy_cli import log
+
+log = logging.getLogger(__name__)
 
 
 # this module will host post reconstuction data analysis (segmentation, etc.)

--- a/tomopy_cli/prep.py
+++ b/tomopy_cli/prep.py
@@ -1,13 +1,18 @@
 import os
 import json
+import logging
+
 import tomopy
 import dxchange
 import numpy as np
 
-from tomopy_cli import log
 from tomopy_cli import file_io
 from tomopy_cli import beamhardening
 from tomopy_cli import config
+
+
+log = logging.getLogger(__name__)
+
 
 def all(proj, flat, dark, params, sino):
     # zinger_removal

--- a/tomopy_cli/recon.py
+++ b/tomopy_cli/recon.py
@@ -4,16 +4,21 @@ import shutil
 from pathlib import Path
 from multiprocessing import cpu_count
 import threading
+import logging
+
 import numpy as np
 import tomopy
 import dxchange
 
-from tomopy_cli import log
 from tomopy_cli import file_io
 from tomopy_cli import config
 from tomopy_cli import prep
 from tomopy_cli import beamhardening
 from tomopy_cli import find_center
+
+
+log = logging.getLogger(__name__)
+
 
 def rec(params):
     

--- a/tomopy_cli/util.py
+++ b/tomopy_cli/util.py
@@ -1,6 +1,9 @@
+import logging
+
 import numpy as np
 
-from tomopy_cli import log
+
+log = logging.getLogger(__name__)
 
 
 def theta_step(start, end, proj_number):


### PR DESCRIPTION
This PR brings the logging mechanism back in line with the standard library logging. ``setup_custom_logger`` still adds the colors to the terminal, and sets up a log file, but everything is now attached to the "tomopy_cli." parent logger, so each module can have it's own call to ``logging.getLogger(__name__)``. ``setup_custom_logger`` adds handlers to this parent logger.

The benefit of this is that it preserves all the metadata for log entries. In the old setup, each module called the ``debug()`` function (or whatever) in the log.py module, and so every log record was emitted from log.py line 15, which is not entirely helpful.

This PR also makes use of the --verbose flag to set the console to log with either debug or info levels. The log file always records with the debug level.