### PR TITLE
Beamtime fixes 2020-07-30

### DIFF
--- a/bin/tomopy
+++ b/bin/tomopy
@@ -74,6 +74,7 @@ def run_rec(args):
             # Load the list of files from a given JSON rotation_axis file
             log.info("Reconstructing files listed in: %s" % args.file_name)
             file_dict = file_io.read_rot_centers_json(file_path)
+            args.rotation_axis_file = str(file_path)
             for new_file_name, rot_center in file_dict.items():
                 args.file_name = str(file_path.parent / new_file_name)
                 args.rotation_axis = rot_center

--- a/bin/tomopy
+++ b/bin/tomopy
@@ -5,7 +5,7 @@ import re
 import sys
 import argparse
 import time
-import pathlib
+from pathlib import Path
 from datetime import datetime
 
 from tomopy_cli import config, __version__
@@ -20,24 +20,25 @@ from tomopy_cli.auto_complete import create_complete_tomopy
 log = logging.getLogger('tomopy_cli.bin.tomopy')
 
 
-def init(args):
+KNOWN_FORMATS = ['dx', 'aps2bm', 'aps7bm', 'aps32id']
 
+
+def init(args):
     if not os.path.exists(str(args.config)):
         config.write(args.config)
     else:
         log.error("{0} already exists".format(args.config))    
 
-def run_status(args):
 
+def run_status(args):
     config.log_values(args)
 
-def run_find_center(args):
 
-    if (str(args.file_format) in {'dx', 'aps2bm', 'aps7bm', 'aps32id'}):
+def run_find_center(args):
+    if (str(args.file_format) in KNOWN_FORMATS):
         log.warning('find center start')
         args = find_center.find_rotation_axis(args)
         log.warning('find center end')
-
         # update tomopy.conf
         sections = config.RECON_PARAMS
         config.write(args.config, args=args, sections=sections)
@@ -67,15 +68,24 @@ def run_rec(args):
 
     log.warning('reconstruction start')
 
-    if (str(args.file_format) in {'dx', 'aps2bm', 'aps7bm', 'aps32id'}):
-        if os.path.isfile(args.file_name):    
-            log.info("reconstructing a single file: %s" % args.file_name)   
+    if str(args.file_format) in KNOWN_FORMATS:
+        file_path = Path(args.file_name)
+        if file_path.suffix == '.json':
+            # Load the list of files from a given JSON rotation_axis file
+            log.info("Reconstructing files listed in: %s" % args.file_name)
+            file_dict = file_io.read_rot_centers_json(file_path)
+            for new_file_name, rot_center in file_dict.items():
+                args.file_name = str(file_path.parent / new_file_name)
+                args.rotation_axis = rot_center
+                recon.rec(args)
+            config.update_config(args)
+        elif os.path.isfile(args.file_name):
+            log.info("reconstructing a single file: %s" % args.file_name)
             recon.rec(args)
             config.update_config(args)
         elif os.path.isdir(args.file_name):
             # Add a trailing slash if missing
             top = os.path.join(args.file_name, '')
-
             h5_file_list = list(filter(lambda x: x.endswith(('.h5', '.hdf', 'hdf5')), os.listdir(top)))
             if (h5_file_list):
                 h5_file_list.sort()
@@ -115,7 +125,7 @@ def run_rec(args):
     else:
         # add here support for other file formats
         log.error("  *** %s is not a supported file format" % args.file_format)
-        log.error("supported data formats are: %s, %s, %s, %s" % ('dx', 'aps2bm', 'aps7bm', 'aps32id'))
+        log.error("supported data formats are: %s, %s, %s, %s" % tuple(KNOWN_FORMATS))
 
 
 def main():

--- a/bin/tomopy
+++ b/bin/tomopy
@@ -74,10 +74,10 @@ def run_rec(args):
             # Load the list of files from a given JSON rotation_axis file
             log.info("Reconstructing files listed in: %s" % args.file_name)
             file_dict = file_io.read_rot_centers_json(file_path)
-            args.rotation_axis_file = str(file_path)
-            for new_file_name, rot_center in file_dict.items():
-                args.file_name = str(file_path.parent / new_file_name)
-                args.rotation_axis = rot_center
+            # args.rotation_axis_file = str(file_path)
+            for filename_idx, file_info in file_dict.items():
+                new_file_name = list(file_info.keys())[0]
+                args.file_name = file_path.parent / new_file_name
                 recon.rec(args)
             config.update_config(args)
         elif os.path.isfile(args.file_name):

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -60,6 +60,25 @@ After using **find_center**, to do a tomographic reconstruction of all tomograph
     $ tomopy recon --file-name /local/data/
 
 
+Manually Specifying Rotation Center
+===================================
+
+The rotation center can be specified using the ``--rotation-axis``
+argument, or through a JSON file with a schema resembling::
+
+    {
+      "path_to_my_data_file_A.h5": 1017.0,
+      "path_to_my_data_file_B.h5": 1025.0,
+    }
+
+Including a JSON file can be beneficial if rotation centers cannot be
+accurately determined automatically. The path to this JSON file can
+either be given as ``--rotation-axis-file``, in which case only the
+file given by ``--file-name`` is reconstructed, or directly as the
+argument to ``--file-name``, in which case all files in the JSON
+object will be reconstructed.
+
+
 Help
 ====
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -47,8 +47,8 @@ To automatically find the rotation axis location of all tomographic hdf data set
 this generates in the /local/data/ directory a **rotation_axis.json** file containing all the automatically calculated centers::
 
             {"0": {"proj_0000.hdf": 1287.25}, "1": {"proj_0001.hdf": 1297.75},
-            {"2": {"proj_0002.hdf": 1287.25}, "3": {"proj_0003.hdf": 1297.75},
-            {"4": {"proj_0004.hdf": 1287.25}, "5": {"proj_0005.hdf": 1297.75}}
+             "2": {"proj_0002.hdf": 1287.25}, "3": {"proj_0003.hdf": 1297.75},
+             "4": {"proj_0004.hdf": 1287.25}, "5": {"proj_0005.hdf": 1297.75}}
 
 to list of all available options::
 
@@ -66,18 +66,17 @@ Manually Specifying Rotation Center
 The rotation center can be specified using the ``--rotation-axis``
 argument, or through a JSON file with a schema resembling::
 
-    {
-      "path_to_my_data_file_A.h5": 1017.0,
-      "path_to_my_data_file_B.h5": 1025.0,
-    }
+           {"0": {"proj_0000.hdf": 1287.25}, "1": {"proj_0001.hdf": 1297.75},
+            "2": {"proj_0002.hdf": 1287.25}, "3": {"proj_0003.hdf": 1297.75},
+            "4": {"proj_0004.hdf": 1287.25}, "5": {"proj_0005.hdf": 1297.75}}
 
 Including a JSON file can be beneficial if rotation centers cannot be
-accurately determined automatically. The path to this JSON file can
-either be given as ``--rotation-axis-file``, in which case only the
-file given by ``--file-name`` is reconstructed, or directly as the
-argument to ``--file-name``, in which case all files in the JSON
-object will be reconstructed.
-
+accurately determined automatically. The path to this JSON file can be
+given as ``--rotation-axis-file`` with
+``--rotation-axis-auto=json``. If ``--file-name`` points to a source
+data file, only the file given by ``--file-name`` is reconstructed.
+If the JSON file is also given as the argument to ``--file-name``,
+then all data files listed in the JSON file will be reconstructed.
 
 Help
 ====

--- a/tests/test_executable.py
+++ b/tests/test_executable.py
@@ -1,0 +1,59 @@
+import unittest
+from unittest import mock
+from pathlib import Path
+import sys
+
+# Import the tomopy executable file
+from importlib.util import spec_from_loader, module_from_spec
+from importlib.machinery import SourceFileLoader 
+bin_dir = str(Path(__file__).parent.parent / "bin" / "tomopy")
+spec = spec_from_loader("tomopy", SourceFileLoader("tomopy", bin_dir))
+tomopy_bin = module_from_spec(spec)
+spec.loader.exec_module(tomopy_bin)
+sys.modules['tomopy_bin'] = tomopy_bin
+
+
+def make_params():
+    params = mock.MagicMock()
+    params.file_name = "test_tomogram.h5"
+    params.rotation_axis = 32
+    params.file_type = 'standard'
+    params.file_format = 'dx'
+    params.start_row = 0
+    params.end_row = -1
+    params.binning = 0
+    params.nsino_per_chunk = 256
+    params.flat_correction_method = 'standard'
+    params.reconstruction_algorithm = 'gridrec'
+    params.gridrec_filter = 'parzen'
+    params.reconstruction_mask_ratio = 1.0
+    params.reconstruction_type = 'slice'
+    return params
+
+
+class RotationAxisFileTests(unittest.TestCase):
+    """Check that file names can be read from a rotation-axis.json
+    file.
+    
+    """
+    rot_axis_file = Path(__file__).resolve().parent / 'rotation_axis.json'
+    def setUp(self):
+        if self.rot_axis_file.exists():
+            self.rot_axis_file.unlink()
+        # Create a rotation_axis.json file
+        with open(self.rot_axis_file, mode='x') as fp:
+            fp.write('{"0": {"test_tomogram.h5": 1287.25}}')
+    
+    def tearDown(self):
+        if self.rot_axis_file.exists():
+            self.rot_axis_file.unlink()
+
+    @mock.patch('tomopy_bin.recon.rec')
+    @mock.patch('tomopy_bin.config.update_config')
+    def test_filename_from_json_file(self, update_config_func, rec_func):
+        params = make_params()
+        params.file_name = self.rot_axis_file
+        response = tomopy_bin.run_rec(params)
+        self.assertEqual(str(params.file_name), '/home/mwolf/src/tomopy-cli/tests/test_tomogram.h5')
+        self.assertEqual(params.rotation_axis, 32)
+

--- a/tests/test_recon.py
+++ b/tests/test_recon.py
@@ -31,9 +31,9 @@ def make_params():
 
 
 class ReconTests(TestCase):
-    output_dir = Path(__file__).resolve().parent.parent / 'tests_rec'
-    output_hdf = Path(__file__).resolve().parent.parent / 'tests_rec' / 'test_tomogram_rec.hdf5'
-    full_tiff_dir = Path(__file__).resolve().parent.parent / 'tests_rec' / 'test_tomogram_rec'
+    output_dir = Path(__file__).resolve().parent / '_rec'
+    output_hdf = Path(__file__).resolve().parent / '_rec' / 'test_tomogram_rec.hdf'
+    full_tiff_dir = Path(__file__).resolve().parent / '_rec' / 'test_tomogram_rec'
 
     def setUp(self):
         # Remove the temporary HDF5 file
@@ -62,21 +62,22 @@ class ReconTests(TestCase):
         params = make_params()
         params.reconstruction_type = 'slice'
         response = rec(params=params)
+        print(self.output_dir)
         self.assertTrue(self.output_dir.exists())
     
     def test_full_reconstruction(self):
         """Check that a basic reconstruction completes and produces output tiff files."""
         params = make_params()
         params.reconstruction_type = 'full'
-        params.output_format = 'tiff'
+        params.output_format = 'tiff_stack'
         response = rec(params=params)
-        print(self.full_tiff_dir)
         # import pdb; pdb.set_trace()
         self.assertTrue(self.full_tiff_dir.exists())
     
     def test_hdf_output(self):
         params = make_params()
         params.reconstruction_type = 'full'
+        params.output_format = "hdf5"
         response = rec(params=params)
         expected_hdf5path = self.output_hdf
         # Check that tiffs are not saved and HDF5 file is saved
@@ -91,6 +92,7 @@ class ReconTests(TestCase):
         # Test with multiple chunks to ensure they're all written
         params = make_params()
         params.reconstruction_type = 'full'
+        params.output_format = 'hdf5'
         params.nsino_per_chunk = 16 # 4 chunks
         response = rec(params=params)
         expected_hdf5path = self.output_hdf

--- a/tests/test_recon.py
+++ b/tests/test_recon.py
@@ -10,11 +10,12 @@ import tomopy
 from tomopy_cli.recon import rec
 
 HDF_FILE = Path(__file__).resolve().parent / 'test_tomogram.h5'
+ROT_AXIS_FILE = Path(__file__).resolve().parent / 'rotation_axis.json'
 
 
 def make_params():
     params = mock.MagicMock()
-    params.file_name = str(HDF_FILE)
+    params.file_name = HDF_FILE
     params.rotation_axis = 32
     params.file_type = 'standard'
     params.file_format = 'dx'
@@ -37,22 +38,22 @@ class ReconTests(TestCase):
 
     def setUp(self):
         # Remove the temporary HDF5 file
-        if os.path.exists(str(HDF_FILE)):
-            os.remove(str(HDF_FILE))
+        if HDF_FILE.exists():
+            HDF_FILE.unlink()
         # Prepare some dummy data
         phantom = tomopy.misc.phantom.shepp3d(size=64)
         phantom = np.exp(-phantom)
         flat = np.ones((2, *phantom.shape[1:]))
         dark = np.zeros((2, *phantom.shape[1:]))
-        with h5py.File(str(HDF_FILE), mode='w-') as fp:
+        with h5py.File(HDF_FILE, mode='w-') as fp:
             fp.create_dataset('/exchange/data', data=phantom)
             fp.create_dataset('/exchange/data_white', data=flat)
             fp.create_dataset('/exchange/data_dark', data=dark)
     
     def tearDown(self):
         # Remove the temporary HDF5 file
-        if os.path.exists(str(HDF_FILE)):
-            os.remove(str(HDF_FILE))
+        if HDF_FILE.exists():
+            HDF_FILE.unlink()
         # Remove the reconstructed output
         if self.output_dir.exists():
             shutil.rmtree(self.output_dir)

--- a/tomopy_cli/config.py
+++ b/tomopy_cli/config.py
@@ -1,7 +1,7 @@
 import os
 import sys
 import shutil
-import pathlib
+from pathlib import Path
 import argparse
 import configparser
 from collections import OrderedDict
@@ -17,8 +17,8 @@ from tomopy_cli import __version__
 log = logging.getLogger(__name__)
 
 
-LOGS_HOME = os.path.join(str(pathlib.Path.home()), 'logs')
-CONFIG_FILE_NAME = os.path.join(str(pathlib.Path.home()), 'tomopy.conf')
+LOGS_HOME = Path.home()/'logs'
+CONFIG_FILE_NAME = Path.home()/'tomopy.conf'
 ROTATION_AXIS_FILE_NAME = "rotation_axis.json"
 
 SECTIONS = OrderedDict()
@@ -74,7 +74,7 @@ SECTIONS['find-rotation-axis'] = {
 SECTIONS['file-reading'] = {
     'file-name': {
         'default': '.',
-        'type': str,
+        'type': Path,
         'help': "Name of the last used hdf file or directory containing multiple hdf files",
         'metavar': 'PATH'},
     'file-format': {

--- a/tomopy_cli/config.py
+++ b/tomopy_cli/config.py
@@ -63,8 +63,8 @@ SECTIONS['find-rotation-axis'] = {
     'rotation-axis-auto': {
         'default': 'read_auto',
         'type': str,
-        'help': "How to get rotation axis: read from HDF5, auto calculate, or take from this file",
-        'choices': ['read_auto', 'read_manual', 'manual', 'auto']},
+        'help': "How to get rotation axis: read from HDF5, auto calculate, read from json file, or take from this file",
+        'choices': ['read_auto', 'read_manual', 'manual', 'auto', 'json']},
     'rotation-axis-flip': {
         'default': -1.0,
         'type': float,

--- a/tomopy_cli/file_io.py
+++ b/tomopy_cli/file_io.py
@@ -308,26 +308,31 @@ def path_base_name(path):
     return file_base_name(fname)
 
 
-def read_rot_centers(params):
-
-    # Add a trailing slash if missing
-    top = os.path.join(params.file_name, '')
-
-    # Load the the rotation axis positions.
-    jfname = top + params.rotation_axis_file
-    
+def read_rot_centers_json(json_path):
     try:
-        with open(jfname) as json_file:
+        with open(json_path) as json_file:
             json_string = json_file.read()
             dictionary = json.loads(json_string)
+    except FileNotFoundError:
+        log.error("the json %s file containing the rotation axis locations is missing" % json_path)
+        log.error("to create one run:")
+        log.error("$ tomopy find_center")
+        exit()
+    except json.decoder.JSONDecodeError as e:
+        log.error("the json %s file containing the rotation axis locations is malformed" % json_path)
+        log.error(e)
+        exit()
+    else:
+        return dictionary
+    
 
-        return collections.OrderedDict(sorted(dictionary.items()))
-
-    except Exception as error: 
-        log.warning("the json %s file containing the rotation axis locations is missing" % jfname)
-        log.warning("to create one run:")
-        log.warning("$ tomopy find_center --file-name %s" % top)
-        # exit()
+def read_rot_centers(params):
+    # Prepend the data directory to the json path
+    fpath = Path(params.file_name)
+    jfpath = fpath / params.rotation_axis_file
+    # Load and return the json data
+    dictionary = read_rot_centers_json(jfpath)
+    return collections.OrderedDict(sorted(dictionary.items()))
 
 
 def auto_read_dxchange(params):
@@ -347,15 +352,19 @@ def read_rot_center(params):
     Return: rotation center from this dataset or None if it doesn't exist.
     """
     log.info('  *** *** rotation axis')
-    #Handle case of manual only: this is the easiest
+    # Handle case of manual only: this is the easiest
     if params.rotation_axis_auto == 'manual':
         log.warning('  *** *** Force use of config file value = {:f}'.format(params.rotation_axis))
     elif params.rotation_axis_auto == 'auto':
         log.warning('  *** *** Force auto calculation without reading config value')
         log.warning('  *** *** Computing rotation axis')
-        params = find_center.find_rotation_axis(params) 
+        params = find_center.find_rotation_axis(params)
+    elif params.rotation_axis_auto == 'json':
+        log.warning('  *** *** Reading rotation axis from json file: %s', params.rotation_axis_file)
+        all_centers = read_rot_centers_json(Path(params.rotation_axis_file))
+        params.rotation_axis = all_centers[params.file_name]
     else:
-        #Try to read from HDF5 file
+        # Try to read from HDF5 file
         log.warning('  *** *** Try to read rotation center from file {:s}'.format(params.file_name))
         with h5py.File(params.file_name, 'r') as file_name:
             try:

--- a/tomopy_cli/file_io.py
+++ b/tomopy_cli/file_io.py
@@ -309,6 +309,7 @@ def path_base_name(path):
 
 
 def read_rot_centers_json(json_path):
+    print(json_path)
     try:
         with open(json_path) as json_file:
             json_string = json_file.read()
@@ -329,10 +330,18 @@ def read_rot_centers_json(json_path):
 def read_rot_centers(params):
     # Prepend the data directory to the json path
     fpath = Path(params.file_name)
-    jfpath = fpath / params.rotation_axis_file
+    if fpath.is_dir():
+        jfpath = fpath / params.rotation_axis_file
+    else:
+        jfpath = params.rotation_axis_file
     # Load and return the json data
     dictionary = read_rot_centers_json(jfpath)
-    return collections.OrderedDict(sorted(dictionary.items()))
+    dictionary = collections.OrderedDict(sorted(dictionary.items()))
+    subdict = collections.OrderedDict()
+    for idx, payload in dictionary.items():
+        key, val = next(iter(payload.items()))
+        subdict[key] = val
+    return subdict
 
 
 def auto_read_dxchange(params):
@@ -361,11 +370,11 @@ def read_rot_center(params):
         params = find_center.find_rotation_axis(params)
     elif params.rotation_axis_auto == 'json':
         log.warning('  *** *** Reading rotation axis from json file: %s', params.rotation_axis_file)
-        all_centers = read_rot_centers_json(Path(params.rotation_axis_file))
-        params.rotation_axis = all_centers[params.file_name]
+        all_centers = read_rot_centers(params)
+        params.rotation_axis = all_centers[params.file_name.name]
     else:
         # Try to read from HDF5 file
-        log.warning('  *** *** Try to read rotation center from file {:s}'.format(params.file_name))
+        log.warning('  *** *** Try to read rotation center from file {}'.format(params.file_name))
         with h5py.File(params.file_name, 'r') as file_name:
             try:
                 dataset = '/process' + '/tomopy-cli-' + __version__ + '/' + 'find-rotation-axis' + '/'+ 'rotation-axis'

--- a/tomopy_cli/file_io.py
+++ b/tomopy_cli/file_io.py
@@ -309,7 +309,6 @@ def path_base_name(path):
 
 
 def read_rot_centers_json(json_path):
-    print(json_path)
     try:
         with open(json_path) as json_file:
             json_string = json_file.read()
@@ -339,7 +338,10 @@ def read_rot_centers(params):
     dictionary = collections.OrderedDict(sorted(dictionary.items()))
     subdict = collections.OrderedDict()
     for idx, payload in dictionary.items():
-        key, val = next(iter(payload.items()))
+        try:
+            key, val = next(iter(payload.items()))
+        except AttributeError:
+            raise RuntimeError("Malformed rotation-axis file.")
         subdict[key] = val
     return subdict
 

--- a/tomopy_cli/find_center.py
+++ b/tomopy_cli/find_center.py
@@ -20,8 +20,7 @@ def find_rotation_axis(params):
 
     fname = params.file_name
     ra_fname = params.rotation_axis_file
-
-    if os.path.isfile(fname):  
+    if os.path.isfile(fname):
         return _find_rotation_axis(params)
         
     elif os.path.isdir(fname):

--- a/tomopy_cli/recon.py
+++ b/tomopy_cli/recon.py
@@ -116,15 +116,19 @@ def rec(params):
                                                           'overwrite': True})
             else:
                 fname = recon_base_dir / "{}.hdf".format(tail)
+                # file_io.write_hdf5(rec, fname=str(fname), dest_idx=slice(strt, strt+rec.shape[0]),
+                #                    maxsize=(sino_end, *rec.shape[1:]), overwrite=(iChunk==0))
+                ds_end = int(np.ceil(sino_end / pow(2, int(params.binning))))
                 write_thread = threading.Thread(target=file_io.write_hdf5,
                                                 args = (rec,),
                                                 kwargs = {'fname': str(fname),
                                                           'dest_idx': slice(strt, strt+rec.shape[0]),
-                                                          'maxsize': (sino_end, *rec.shape[1:]),
+                                                          'maxsize': (ds_end, *rec.shape[1:]),
                                                           'overwrite': iChunk==0})
+            # strt += int((sino[1] - sino[0]) / np.power(2, float(params.binning)))
             write_thread.start()
             write_threads.append(write_thread)
-            strt += int((sino[1] - sino[0]) / np.power(2, float(params.binning)))
+            strt += (sino[1] - sino[0])
         elif params.reconstruction_type == "slice":
             # Construct the path for where to save the tiffs
             fname = Path(params.file_name)

--- a/tomopy_cli/recon.py
+++ b/tomopy_cli/recon.py
@@ -135,7 +135,7 @@ def rec(params):
         thread.join()
 
 def _try_rec(params):
-    log.info("  *** *** starting 'try' reconstruction") 
+    log.info("  *** *** starting 'try' reconstruction")
     data_shape = file_io.get_dx_dims(params)
     # Select sinogram range to reconstruct
     nSino_per_chunk = pow(2, int(params.binning))
@@ -173,7 +173,7 @@ def _try_rec(params):
             blocked_views = params.blocked_views_end - params.blocked_views_start
             stack = np.empty((len(center_range), data_shape[0]-blocked_views, int(data_shape[2])))
         else:
-            stack = np.empty((len(center_range), data_shape[0], int(data_shape[2])))
+            stack = np.empty((len(center_range), data.shape[0], int(data.shape[2])))
 
         for i, axis in enumerate(center_range):
             stack[i] = data[:, 0, :]

--- a/tomopy_cli/recon.py
+++ b/tomopy_cli/recon.py
@@ -117,7 +117,6 @@ def rec(params):
             elif params.output_format == "hdf5":
                 # HDF5 output
                 fname = recon_base_dir / "{}.hdf".format(tail)
-                print(fname)
                 # file_io.write_hdf5(rec, fname=str(fname), dest_idx=slice(strt, strt+rec.shape[0]),
                 #                    maxsize=(sino_end, *rec.shape[1:]), overwrite=(iChunk==0))
                 ds_end = int(np.ceil(sino_end / pow(2, int(params.binning))))

--- a/tomopy_cli/recon.py
+++ b/tomopy_cli/recon.py
@@ -5,6 +5,7 @@ from multiprocessing import cpu_count
 import threading
 import logging
 
+import matplotlib.pyplot as plt
 import numpy as np
 import tomopy
 import dxchange
@@ -304,11 +305,12 @@ def reconstruct(data, theta, rot_center, params):
             rec = tomopy.misc.corr.gaussian_filter(rec, axis=2)
         shift = (int((data.shape[2]/2 - rot_center)+.5))
         data = np.roll(data, shift, axis=2)
+        recon_kw = dict(center=rot_center, algorithm=tomopy.astra,
+                        options=options)
         if params.astrasirt_bootstrap:
             log.info('  *** *** using gridrec to start astrasirt recon')
-            rec = tomopy.recon(data, theta, init_recon=rec, algorithm=tomopy.astra, options=options)
-        else:
-            rec = tomopy.recon(data, theta, algorithm=tomopy.astra, center=params.rotation_axis, options=options)
+            recon_kw['init_recon'] = rec
+        rec = tomopy.recon(data, theta, **recon_kw)
     elif params.reconstruction_algorithm == 'astrasart':
         extra_options ={}
         try:

--- a/tomopy_cli/recon.py
+++ b/tomopy_cli/recon.py
@@ -114,8 +114,10 @@ def rec(params):
                                                 kwargs = {'fname': str(fname),
                                                           'start': strt,
                                                           'overwrite': True})
-            else:
+            elif params.output_format == "hdf5":
+                # HDF5 output
                 fname = recon_base_dir / "{}.hdf".format(tail)
+                print(fname)
                 # file_io.write_hdf5(rec, fname=str(fname), dest_idx=slice(strt, strt+rec.shape[0]),
                 #                    maxsize=(sino_end, *rec.shape[1:]), overwrite=(iChunk==0))
                 ds_end = int(np.ceil(sino_end / pow(2, int(params.binning))))
@@ -125,9 +127,15 @@ def rec(params):
                                                           'dest_idx': slice(strt, strt+rec.shape[0]),
                                                           'maxsize': (ds_end, *rec.shape[1:]),
                                                           'overwrite': iChunk==0})
-            # strt += int((sino[1] - sino[0]) / np.power(2, float(params.binning)))
-            write_thread.start()
-            write_threads.append(write_thread)
+            else:
+                log.error("  *** Unknown output_format '%s'", params.output_format)
+                fname = "<Not saved (bad output-format)>"
+                write_thread = None
+            # Save the data to disk
+            if write_thread is not None:
+                write_thread.start()
+                write_threads.append(write_thread)
+            # Increment counter for which chunks to save
             strt += (sino[1] - sino[0])
         elif params.reconstruction_type == "slice":
             # Construct the path for where to save the tiffs

--- a/tomopy_cli/recon.py
+++ b/tomopy_cli/recon.py
@@ -158,10 +158,10 @@ def _try_rec(params):
             
     sino = (int(sino_start), int(sino_end))
 
-    #Set up the centers of rotation we will use
+    # Set up the centers of rotation we will use
     # Read APS 32-BM raw data.
     proj, flat, dark, theta, rotation_axis = file_io.read_tomo(sino, params, True)
-    # apply all preprocessing functions
+    # Apply all preprocessing functions
     data = prep.all(proj, flat, dark, params, sino)
     rec = []
     center_range = []


### PR DESCRIPTION
This brings in a handful of updates while using tomopy-cli during beamtime at 32-ID-C. 

The biggest change is that "rotation-axis.json" file is now more useful. If ``--rotation-axis-auto=json``, then the rotation axis file is checked even if ``--file-name`` doesn't point to a directory. The rotation axis file can now also be given as as the argument to ``--file-name=``. I needed a way to list specific files to be reconstructed. Instead of coming up with a new specification for listing filenames in a text file, I decided to reuse the JSON format for specifying rotation centers. If a *rotation-axis.json* file is given to ``--rotation-axis-file`` it works normally. If a *rotation-axis.json* file is given to ``--file-name``, then only the files listed in the JSON file will be reconstructed. This is described in the "usage" page of the documentation.

I changed what may or may not be a bug in the default directory for saving reconstructions. During beamtime, doing reconstructions in the directory ``/local/dataraid/2020-07/Wolfman`` would create a new directory ``/local/dataraid/2020-07/Wolfman_rec``. I think the right behavior is to create ``/local/dataraid/2020-07/Wolfman/_rec``, but feel free to disagree.

I also replaced a lot of *os.path* operations with their *pathlib* counterparts.

Let me know if anything looks wrong.