### PR TITLE
Added a config parameter for specifying the output folder for reconstructions

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -36,6 +36,26 @@ To run a reconstruction with a different and previously stored configuration fil
     $ tomopy recon --config old_tomopy.conf
 
 
+Output Folder
+=============
+
+The output folder for reconstructed data can be given with the
+``--output-folder`` option. The other configuration parameters can be
+inserted with curly braces::
+
+  $ tomopy recon --output-folder={file_name}_rec
+
+An additional parameter (``{file_name_parent}``) is given with the
+path of the parent directory. If ``--file-name`` is a directory, then
+``{file_name_parent}`` will contain the directory itself. If
+``--file-name`` is a file, then ``{file_name_parent}`` will be the
+parent directory of the file. The following lines will both place
+reconstructed data in the directory */path/to/my/data_rec/*::
+
+   $ tomopy recon --file-name=/path/to/my/data/file.hdf --output-folder={file_name_parent}_rec/
+   $ tomopy recon --file-name=/path/to/my/data/ --output-folder={file_name_parent}_rec/
+
+
 Find Center
 ===========
 

--- a/tomopy_cli/config.py
+++ b/tomopy_cli/config.py
@@ -356,6 +356,13 @@ SECTIONS['reconstruction'] = {
         'help': "How to save the reconstructed data. Only applies when ``reconstruction-type == 'full'``.",
         'choices': ['tiff_stack', 'hdf5'],
         },
+    'output-folder': {
+        'default': "{file_name_parent}_rec",
+        'type': str,
+        'help': ("Where to save the reconstructed data. Can accept other parameters "
+                 "and extra tokens (file_name_parent). "
+                 "Eg: \"{file_name_parent}_rec/{reconstruction_algorithm}/\"")
+        },
     }
 
 SECTIONS['gridrec'] = {

--- a/tomopy_cli/recon.py
+++ b/tomopy_cli/recon.py
@@ -102,13 +102,12 @@ def rec(params):
         # Reconstruct: this is for "slice" and "full" methods
         rec = padded_rec(data, theta, rotation_axis, params)
         # Save images
+        recon_base_dir = reconstruction_folder(params)
+        fpath = Path(params.file_name).resolve()
         if params.reconstruction_type == "full":
-            fpath = Path(params.file_name).resolve()
-            recon_base_dir = Path("{}_rec".format(fpath.parent)) / "{}_rec".format(fpath.stem) 
-            
-
+            recon_dir = recon_base_dir / "{}_rec".format(fpath.stem)
             if params.output_format == 'tiff_stack':
-                fname = recon_base_dir / 'recon'
+                fname = recon_dir / 'recon'
                 log.debug("Full tiff dir: %s", fname)
                 write_thread = threading.Thread(target=dxchange.write_tiff_stack,
                                                 args = (rec,),
@@ -117,7 +116,7 @@ def rec(params):
                                                           'overwrite': True})
             elif params.output_format == "hdf5":
                 # HDF5 output
-                fname = "{}.hdf".format(recon_base_dir)
+                fname = "{}.hdf".format(recon_dir)
                 # file_io.write_hdf5(rec, fname=str(fname), dest_idx=slice(strt, strt+rec.shape[0]),
                 #                    maxsize=(sino_end, *rec.shape[1:]), overwrite=(iChunk==0))
                 ds_end = int(np.ceil(sino_end / pow(2, int(params.binning))))
@@ -139,9 +138,8 @@ def rec(params):
             strt += (sino[1] - sino[0])
         elif params.reconstruction_type == "slice":
             # Construct the path for where to save the tiffs
-            fpath = Path(params.file_name).resolve()
-            fname = Path("{}_rec".format(fpath.parent))  / 'slice_rec' / 'recon_{}'.format(fpath.stem)
-            dxchange.write_tiff(rec, fname=str(fname), overwrite=True)
+            fname = recon_base_dir / 'slice_rec' / 'recon_{}'.format(fpath.stem)
+            dxchange.write_tiff(rec, fname=str(fname), overwrite=False)
         else:
             raise ValueError("Unknown value for *reconstruction type*: {}. "
                              "Valid options are {}"
@@ -404,7 +402,6 @@ def reconstruct(data, theta, rot_center, params):
 
 
 def mask(data, params):
-
     log.info("  *** mask")
     if(params.reconstruction_mask):
         log.info('  *** *** ON')
@@ -417,3 +414,18 @@ def mask(data, params):
     else:
         log.warning('  *** *** OFF')
     return data
+
+
+def reconstruction_folder(params):
+    """Build the path to the folder that will receive the reconstruction.
+    
+    """
+    file_path = Path(params.file_name).resolve()
+    folder_fmt = params.output_folder
+    # Format the folder name with the config parameters
+    if file_path.is_dir():
+        file_name_parent = file_path
+    else:
+        file_name_parent = file_path.parent
+    folder_fmt = folder_fmt.format(file_name_parent=file_name_parent, **params.__dict__)
+    return Path(folder_fmt)


### PR DESCRIPTION
It looks like @nikitinvv and I are unknowingly having a commit fight over the folder used for storing reconstructed data. One prefers */path/to/my/data/_rec* and the other uses */path/to/my/data_rec*.

To solve this, I added a configuration parameter (``--output-folder``) to specify the output folder. This parameter can also accept other config parameters plus the special token *{file_name_parent}*. The default value ``--output-folder={file_name_parent}_rec`` will cause the command ``$ tomopy recon --file-name=/path/to/my/data/file.h5`` to save reconstructions in */path/to/my/data_rec/*, which is the current behavior as of 86af5c23a230c2804d11812d336641712e586aad.

PR inclues tests (fixed after breaking with 86af5c23a230c2804d11812d336641712e586aad) and documentation.

