### PR TITLE
Added support for Vo's stripe removal and a tomopy-cli logo

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,7 +3,7 @@ tomopy-cli
 ==========
 
 
-.. image:: source/img/project-logo.png
+.. image:: source/img/tomopy-cli-logo.svg
    :width: 320px
    :alt: project
 
@@ -29,7 +29,7 @@ Content
 -------
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
 
    source/install
    source/usage

--- a/docs/source/img/tomopy-cli-logo.svg
+++ b/docs/source/img/tomopy-cli-logo.svg
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   width="2208.2864"
+   height="740.29675"
+   viewBox="0 0 584.27579 195.87019"
+   version="1.1"
+   id="svg5939">
+  <defs
+     id="defs5933" />
+  <metadata
+     id="metadata5936">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     transform="translate(87.648846,-133.25695)"
+     style="display:inline">
+    <g
+       id="layer3"
+       style="display:inline;mix-blend-mode:normal">
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;fill:#1e1e1e;fill-opacity:1;stroke:#800000;stroke-width:0.461113;stroke-linecap:round;stroke-linejoin:round"
+         id="rect848"
+         width="583.81464"
+         height="195.40907"
+         x="-87.418289"
+         y="133.4875"
+         ry="84.711952" />
+    </g>
+    <g
+       id="layer2"
+       style="opacity:1">
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:141.111px;line-height:88.1944px;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#a7aaa9;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         x="-60.7831"
+         y="267.67557"
+         id="text910"><tspan
+           id="tspan908"
+           x="-60.7831"
+           y="267.67557"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:141.111px;font-family:monospace;-inkscape-font-specification:'monospace, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#a7aaa9;fill-opacity:1;stroke-width:0.264583px">[  ~]$</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:6.61458px;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         x="296.83655"
+         y="80.958702"
+         id="text1001"><tspan
+           id="tspan999"
+           x="296.83655"
+           y="80.958702"
+           style="stroke-width:0.264583px"></tspan></text>
+    </g>
+    <g
+       id="layer4">
+      <g
+         id="g5931"
+         transform="matrix(0.02132658,0,0,0.02132658,-1.750655,285.21569)"
+         style="display:inline;fill:#a7aaa9;fill-opacity:1">
+        <path
+           id="path908"
+           d="M 4510.939,-2250.6749 A 1359.7334,1359.7334 0 0 1 3474.6973,-1215.2342 V 552.56476 A 3108.8542,3108.8542 0 0 0 6276.1026,-2250.6749 Z"
+           style="display:inline;opacity:1;fill:#4f8fb8;fill-opacity:1;stroke:none;stroke-width:9.49216;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <circle
+           r="793.15814"
+           cy="-2541.7078"
+           cx="3183.6431"
+           id="path1464"
+           style="display:inline;opacity:1;fill:#4f8fb8;fill-opacity:1;stroke:none;stroke-width:7.83228;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path5892"
+           d="M 89.374206,-2250.6749 A 3108.8542,3108.8542 0 0 0 2892.6139,550.73027 V -1214.4074 A 1359.7334,1359.7334 0 0 1 1857.1733,-2250.6749 Z"
+           style="display:inline;opacity:1;fill:#a7aaa9;fill-opacity:1;stroke:none;stroke-width:9.49216;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path5894"
+           d="M 3183.6556,-5650.5708 A 3108.8542,3108.8542 0 0 0 91.208721,-2832.7582 H 1856.3465 a 1359.7334,1359.7334 0 0 1 1327.3091,-1068.6946 1359.7334,1359.7334 0 0 1 1326.4565,1068.6946 h 1767.825 A 3108.8542,3108.8542 0 0 0 3183.6556,-5650.5708 Z"
+           style="display:inline;opacity:1;fill:#a7aaa9;fill-opacity:1;stroke:none;stroke-width:9.49216;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -98,6 +98,30 @@ data file, only the file given by ``--file-name`` is reconstructed.
 If the JSON file is also given as the argument to ``--file-name``,
 then all data files listed in the JSON file will be reconstructed.
 
+Stripe Removal
+==============
+
+Several methods of stripe removal are available in *Tomopy-cli*, and
+can be selected with the ``--remove-stripe`` parameter. Each method
+also has a set of associated parameters for controlling its behavior
+(e.g. ``--remove-stripe=fw`` relies on ``--fw-sigma``,
+``--fw-filter``, etc.).
+
+More information about each method and the accompanying parameters can
+be found in the corresponding *tomopy* documentation:
+
++------------------+----------------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| Method           | ``--remove-stripe=`` Value | Tomopy Function                                                                                                                    |
++==================+============================+====================================================================================================================================+
+| Fourier-Wavelet  | fw                         | `remove_stripe_fw() <https://tomopy.readthedocs.io/en/latest/api/tomopy.prep.stripe.html#tomopy.prep.stripe.remove_stripe_fw>`_    |
++------------------+----------------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| Titarenko        | ti                         | `remove_stripe_ti() <https://tomopy.readthedocs.io/en/latest/api/tomopy.prep.stripe.html#tomopy.prep.stripe.remove_stripe_ti>`_    |
++------------------+----------------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| Smoothing Filter | sf                         | `remove_stripe_sf() <https://tomopy.readthedocs.io/en/latest/api/tomopy.prep.stripe.html#tomopy.prep.stripe.remove_stripe_sf>`_    |
++------------------+----------------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| Vo's Algorithms  | vo-all                     | `remove_all_stripe() <https://tomopy.readthedocs.io/en/latest/api/tomopy.prep.stripe.html#tomopy.prep.stripe.remove_all_stripe>`_  |
++------------------+----------------------------+------------------------------------------------------------------------------------------------------------------------------------+
+
 Help
 ====
 
@@ -105,14 +129,18 @@ Help
 
     $ tomopy -h
     usage: tomopy [-h] [--config FILE] [--version]  ...
-
+    
     optional arguments:
       -h, --help     show this help message and exit
       --config FILE  File name of configuration file
       --version      show program's version number and exit
-
+    
     Commands:
       
         init         Create configuration file
         recon        Run tomographic reconstruction
+        status       Show the tomographic reconstruction status
+        segment      Run segmentation on reconstured data
         find_center  Find rotation axis location for all hdf files in a directory
+        convert      Convert pre-2015 (proj, dark, white) hdf files in a single
+                     data exchange h5 file

--- a/tests/test_file_io.py
+++ b/tests/test_file_io.py
@@ -14,6 +14,9 @@ import matplotlib.pyplot as plt
 from tomopy_cli import file_io
 
 
+TESTDIR = Path(__file__).resolve().parent
+
+
 def make_params():
     params = mock.MagicMock()
     params.file_name = "test_tomogram.h5"
@@ -51,8 +54,8 @@ class FlipAndStitchTests(unittest.TestCase):
 
 
 class ReadParamTests(unittest.TestCase):
-    test_hdf_file = Path('filter-tests.hdf5')
-    rot_axis_file = Path(__file__).resolve().parent / 'rotation_axis.json'
+    test_hdf_file = TESTDIR / 'filter-tests.hdf5'
+    rot_axis_file = TESTDIR / 'rotation_axis.json'
     # Sample filters from 7-BM-B for 'open' and 'Cu_1000um' filters
     filter_open = np.array([[79, 112, 101, 110,] + [0,] * 252], dtype='int8')
     filter_Cu_1000um = np.array([[67, 117,  95,  49,  48,  48, 48, 117, 109,] + [0,] * 247], dtype='int8')
@@ -147,10 +150,10 @@ class ReadParamTests(unittest.TestCase):
 
 
 class ReadTomoScanParamTests(unittest.TestCase):
-    test_hdf_file = Path('meta_mock.h5')
+    test_hdf_file = TESTDIR/'meta_mock.h5'
 
     def setUp(self):
-        self.burner_hdf_file = Path('meta_mock2.h5')
+        self.burner_hdf_file = TESTDIR/'meta_mock2.h5'
         shutil.copy(self.test_hdf_file, self.burner_hdf_file) 
 
 
@@ -214,7 +217,6 @@ class ReadTomoScanParamTests(unittest.TestCase):
     def test_auto_filter(self):
         params = mock.MagicMock()
         params.file_name = str(self.test_hdf_file)
-        print(params.file_name)
         params.filter_1_auto = True
         params.filter_2_auto = True
         params.filter_3_auto = True

--- a/tests/test_prep.py
+++ b/tests/test_prep.py
@@ -1,0 +1,90 @@
+from unittest import mock, TestCase, expectedFailure, skip
+
+import numpy as np
+import tomopy
+
+from tomopy_cli.prep import remove_stripe
+
+
+def make_params():
+    params = mock.MagicMock()
+    return params
+
+
+class StripeRemovalTests(TestCase):
+    def phantom_prj(self, size=64):
+        obj = tomopy.misc.phantom.shepp2d(size=size)
+        prj = tomopy.sim.project.project(obj, np.linspace(0, np.pi/2, size))
+        prj[:,:,size//2] = 0
+        return prj
+    
+    def test_vo_all(self):
+        # Prepare some test data
+        prj = self.phantom_prj()
+        # Prepare parameters
+        params = make_params()
+        params.remove_stripe_method = 'vo-all'
+        params.vo_all_snr = 5
+        params.vo_all_la_size = 5
+        params.vo_all_sm_size = 3
+        result = remove_stripe(np.copy(prj), params)
+        # Compare results
+        expected = tomopy.remove_all_stripe(np.copy(prj), snr=5, la_size=5, sm_size=3)
+        expected[np.isnan(expected)] = 0
+        result[np.isnan(result)] = 0
+        np.testing.assert_array_equal(result, expected)
+    
+    def test_sf(self):
+        # Prepare some test data
+        prj = self.phantom_prj()
+        # Prepare parameters (different from tomopy_cli or tomopy defaults)
+        params = make_params()
+        params.remove_stripe_method = 'sf'
+        params.sf_size = 7
+        result = remove_stripe(np.copy(prj), params)
+        # Compare results
+        expected = tomopy.remove_stripe_sf(np.copy(prj), size=7)
+        np.testing.assert_array_equal(result, expected)
+    
+    def test_fw(self):
+        # Prepare some test data
+        prj = self.phantom_prj()
+        # Prepare parameters (different from tomopy_cli or tomopy defaults)
+        params = make_params()
+        params.remove_stripe_method = 'fw'
+        params.fw_level = 5
+        params.fw_filter = "haar"
+        params.fw_sigma = 1.3
+        result = remove_stripe(np.copy(prj), params)
+        # Compare results
+        expected = tomopy.remove_stripe_fw(np.copy(prj), level=5, wname="haar", sigma=1.3)
+        np.testing.assert_array_equal(result, expected)
+    
+    def test_ti(self):
+        # Prepare some test data
+        prj = self.phantom_prj()
+        # Prepare parameters (different from tomopy_cli or tomopy defaults)
+        params = make_params()
+        params.remove_stripe_method = 'ti'
+        params.ti_alpha = 1.2
+        params.ti_nblock = 2
+        result = remove_stripe(np.copy(prj), params)
+        # Compare results
+        expected = tomopy.remove_stripe_ti(np.copy(prj), alpha=1.2, nblock=2)
+        np.testing.assert_array_equal(result, expected)
+    
+    def test_vo_all(self):
+        # Prepare some test data
+        prj = self.phantom_prj()
+        # Prepare parameters
+        params = make_params()
+        params.remove_stripe_method = 'vo-all'
+        params.vo_all_snr = 5
+        params.vo_all_la_size = 5
+        params.vo_all_sm_size = 3
+        result = remove_stripe(np.copy(prj), params)
+        # Compare results
+        expected = tomopy.remove_all_stripe(np.copy(prj), snr=5, la_size=5, sm_size=3)
+        expected[np.isnan(expected)] = 0
+        result[np.isnan(result)] = 0
+        np.testing.assert_array_equal(result, expected)

--- a/tests/test_recon.py
+++ b/tests/test_recon.py
@@ -63,6 +63,7 @@ class ReconTests(TestCase):
         """Check that a basic reconstruction completes and produces output tiff files."""
         params = make_params()
         params.reconstruction_type = 'slice'
+        params.scintillator_auto = False
         response = rec(params=params)
         self.assertTrue(self.output_dir.exists())
     
@@ -71,6 +72,7 @@ class ReconTests(TestCase):
         params = make_params()
         params.reconstruction_type = 'full'
         params.output_format = 'tiff_stack'
+        params.scintillator_auto = False
         response = rec(params=params)
         # import pdb; pdb.set_trace()
         self.assertTrue(self.full_tiff_dir.exists())
@@ -79,6 +81,7 @@ class ReconTests(TestCase):
         params = make_params()
         params.reconstruction_type = 'full'
         params.output_format = "hdf5"
+        params.scintillator_auto = False
         response = rec(params=params)
         expected_hdf5path = self.output_hdf
         # Check that tiffs are not saved and HDF5 file is saved
@@ -95,6 +98,7 @@ class ReconTests(TestCase):
         params.reconstruction_type = 'full'
         params.output_format = 'hdf5'
         params.nsino_per_chunk = 16 # 4 chunks
+        params.scintillator_auto = False
         response = rec(params=params)
         expected_hdf5path = self.output_hdf
         # Check that tiffs are not saved and HDF5 file is saved

--- a/tomopy_cli/file_io.py
+++ b/tomopy_cli/file_io.py
@@ -595,9 +595,12 @@ def read_scintillator(params):
     '''
     if params.scintillator_auto:
         log.info('  *** auto reading scintillator params')
-        params.scintillator_thickness = float(config.param_from_dxchange(params.file_name, 
-                                            '/measurement/instrument/detection_system/scintillator/scintillating_thickness', 
-                                            attr = None, scalar = True, char_array=False))
+        dataset_name = '/measurement/instrument/detection_system/scintillator/scintillating_thickness'
+        val = config.param_from_dxchange(params.file_name,
+                                         dataset_name, attr=None,
+                                         scalar=True,
+                                         char_array=False)
+        params.scintillator_thickness = float(val)
         log.info('  *** *** scintillator thickness = {:f}'.format(params.scintillator_thickness))
         tomoscan_path = '/measurement/instrument/detection_system/scintillator/name'
         scint_material_string = ''

--- a/tomopy_cli/prep.py
+++ b/tomopy_cli/prep.py
@@ -115,6 +115,11 @@ def remove_stripe(data, params):
         log.info('  *** *** smoothing filter')
         data = tomopy.remove_stripe_sf(data,  size=params.sf_size)
         log.info('  *** ***  *** sf size %d ' % params.sf_size)
+    elif(params.remove_stripe_method == 'vo-all'):
+        log.info('  *** *** Vo\'s algorithms: all')
+        data = tomopy.remove_all_stripe(data, snr=params.vo_all_snr,
+                                        la_size=params.vo_all_la_size,
+                                        sm_size=params.vo_all_sm_size)
     elif(params.remove_stripe_method == 'none'):
         log.warning('  *** *** OFF')
 


### PR DESCRIPTION
I've been getting good results with tomopy's ``remove_all_stripe()`` function and wanted to have it available in tomopy-cli. 

While I was working on the documentation for it I got a little side-tracked adding a logo for the project, too. =P

- Added parameter for ``--remove-stripe=vo-all`` and accompanying tests
- Added tests for all previous stripe removal methods
- Added documentation for stripe removal
- Added a logo to the documentation home page
- Fixed some broken tests for the file-io module