### PR TITLE
Option to limit the maximum value in a sinogram.

### DIFF
--- a/tests/test_find_center.py
+++ b/tests/test_find_center.py
@@ -44,6 +44,7 @@ def make_params():
     params.retrieve_phase_method = 'none'
     params.minus_log = True
     params.fix_nan_and_inf = False
+    params.sinogram_max_value = float('inf')
     return params
 
 

--- a/tests/test_recon.py
+++ b/tests/test_recon.py
@@ -33,6 +33,7 @@ def make_params():
     params.reconstruction_type = 'slice'
     params.scintillator_auto = False
     params.blocked_views = False
+    params.sinogram_max_value = float('inf')
     return params
 
 

--- a/tomopy_cli/config.py
+++ b/tomopy_cli/config.py
@@ -238,7 +238,12 @@ SECTIONS['flat-correction'] = {
         'default': True,
         'help': "Minus log",
         'action': 'store_true'},
-        }
+    'sinogram-max-value': {
+        'default': float('inf'),
+        'help': "Limit the maximum value allowed in the singogram.",
+        'type': float},
+}
+
 
 SECTIONS['retrieve-phase'] = {
     'retrieve-phase-method': {

--- a/tomopy_cli/prep.py
+++ b/tomopy_cli/prep.py
@@ -34,6 +34,7 @@ def all(proj, flat, dark, params, sino):
         data = minus_log(data, params)
     # remove outlier
     data = remove_nan_neg_inf(data, params)
+    data = cap_sinogram_values(data, params)
     return data
 
 
@@ -46,10 +47,14 @@ def remove_nan_neg_inf(data, params):
         data = tomopy.remove_nan(data, val=params.fix_nan_and_inf_value)
         data = tomopy.remove_neg(data, val= 0.0)
         data[np.isinf(data)] = params.fix_nan_and_inf_value
-        data[data > params.fix_nan_and_inf_value] = params.fix_nan_and_inf_value
     else:
         log.warning('  *** *** OFF')
+    return data
 
+
+def cap_sinogram_values(data, params):
+    log.info('  *** cap sinogram max value: %f', params.sinogram_max_value)
+    data[data > params.sinogram_max_value] = params.sinogram_max_value
     return data
 
 


### PR DESCRIPTION
Previously, this was done with the --fix-nan-and-inf-value
option. This is now split out into a new feature --sinogram-max-value.