### PR TITLE
Try extra params

### DIFF
--- a/tests/test_executable.py
+++ b/tests/test_executable.py
@@ -6,8 +6,8 @@ import sys
 # Import the tomopy executable file
 from importlib.util import spec_from_loader, module_from_spec
 from importlib.machinery import SourceFileLoader 
-bin_dir = str(Path(__file__).parent.parent / "bin" / "tomopy")
-spec = spec_from_loader("tomopy", SourceFileLoader("tomopy", bin_dir))
+bin_dir = str(Path(__file__).parent.parent / "bin" / "tomopycli.py")
+spec = spec_from_loader("tomopycli", SourceFileLoader("tomopycli", bin_dir))
 tomopy_bin = module_from_spec(spec)
 spec.loader.exec_module(tomopy_bin)
 sys.modules['tomopy_bin'] = tomopy_bin

--- a/tests/test_find_center.py
+++ b/tests/test_find_center.py
@@ -22,6 +22,8 @@ def make_params():
     params.file_name = HDF_FILE
     params.parameter_file = YAML_FILE
     params.nsino = 0.5
+    params.start_proj = 0
+    params.end_proj = -1
     params.pixel_size_auto = False
     params.filter_1_material = None
     params.filter_1_auto = False

--- a/tests/test_recon.py
+++ b/tests/test_recon.py
@@ -26,6 +26,8 @@ def make_params():
     params.end_row = -1
     params.binning = 0
     params.nsino_per_chunk = 256
+    params.start_proj = 0
+    params.end_proj = -1
     params.flat_correction_method = 'standard'
     params.reconstruction_algorithm = 'gridrec'
     params.gridrec_filter = 'parzen'
@@ -49,12 +51,15 @@ class ReconTestBase(TestCase):
         # Prepare some dummy data
         phantom = tomopy.misc.phantom.shepp3d(size=64)
         phantom = np.exp(-phantom)
+        theta = np.linspace(0, np.pi, num=64)
+        proj = tomopy.sim.project.project(phantom, theta, pad=False)
         flat = np.ones((2, *phantom.shape[1:]))
         dark = np.zeros((2, *phantom.shape[1:]))
         with h5py.File(HDF_FILE, mode='w-') as fp:
-            fp.create_dataset('/exchange/data', data=phantom)
+            fp.create_dataset('/exchange/data', data=proj)
             fp.create_dataset('/exchange/data_white', data=flat)
             fp.create_dataset('/exchange/data_dark', data=dark)
+            fp.create_dataset('/exchange/theta', data=theta)
     
     def tearDown(self):
         # Remove the temporary HDF5 file

--- a/tests/test_recon.py
+++ b/tests/test_recon.py
@@ -144,21 +144,6 @@ class ReconTests(ReconTestBase):
         self.assertEqual(str(output), str(this_file.parent) + "_rec")
 
 
-class TryCenterTests(ReconTestBase):
-    def test_recon_output_dir(self):
-        """Check that ``--reconstruction-type=try`` respects output
-        directory.
-        
-        """
-        params = make_params()
-        params.reconstruction_type = "try"
-        params.center_search_width = 10
-        params.output_folder = "{file_name_parent}/_rec"
-        params.parameter_file = os.devnull
-        response = rec(params=params)
-        self.assertTrue(self.output_dir.exists())
-
-
 class YamlParamsTests(ReconTestBase):
     yaml_file = TEST_DIR / "my_files.yaml"
     def setUp(self):
@@ -185,3 +170,87 @@ class YamlParamsTests(ReconTestBase):
         params = make_params()
         params.parameter_file = self.yaml_file
         response = rec(params=params)
+
+
+class TryCenterTests(ReconTestBase):
+    yaml_file = TEST_DIR / "my_files.yaml"
+    
+    def setUp(self):
+        # Delete any old files 
+        if self.yaml_file.exists():
+            os.remove(self.yaml_file)
+        super().setUp()
+    
+    def tearDown(self):
+        if self.yaml_file.exists():
+            os.remove(self.yaml_file)
+        super().tearDown()
+
+    def test_recon_output_dir(self):
+        """Check that ``--reconstruction-type=try`` respects output
+        directory.
+        
+        """
+        params = make_params()
+        params.reconstruction_type = "try"
+        params.center_search_width = 10
+        params.output_folder = "{file_name_parent}/_rec"
+        params.parameter_file = os.devnull
+        response = rec(params=params)
+        self.assertTrue(self.output_dir.exists())
+
+    def test_extra_args_no_file(self):
+        """Check for behavior if the file is or isn't present in the
+        extra_args yaml file.
+        
+        """
+        params = make_params()
+        params.reconstruction_type = "try"
+        params.center_search_width = 10
+        params.output_folder = "{file_name_parent}/_rec"
+        params.parameter_file = self.yaml_file
+        # Create the YAML file
+        opts = {
+            "other_tomogram.h5": {
+                "spam": "foo",
+                "rotation-axis": 1200,
+            }
+        }
+        with open(self.yaml_file, mode='w') as fp:
+            fp.write(yaml.dump(opts))
+        response = rec(params=params)
+        self.assertTrue(self.output_dir.exists())
+    
+    def test_extra_args_no_rotation_axis(self):
+        """Check for behavior if the file is or isn't present in the
+        extra_args yaml file.
+        
+        """
+        params = make_params()
+        params.reconstruction_type = "try"
+        params.center_search_width = 10
+        params.output_folder = "{file_name_parent}/_rec"
+        params.parameter_file = self.yaml_file
+        # Create the YAML file
+        opts = {
+            "test_tomogram.h5": {
+                "spam": "foo",
+            }
+        }
+        with open(self.yaml_file, mode='w') as fp:
+            fp.write(yaml.dump(opts))
+        response = rec(params=params)
+        self.assertTrue(self.output_dir.exists())
+
+    def test_extra_args_no_file(self):
+        """Check for behavior if the file is or isn't present in the
+        extra_args yaml file.
+        
+        """
+        params = make_params()
+        params.reconstruction_type = "try"
+        params.center_search_width = 10
+        params.output_folder = "{file_name_parent}/_rec"
+        params.parameter_file = "/tmp/gweoiuwerw"
+        response = rec(params=params)
+        self.assertTrue(self.output_dir.exists())

--- a/tomopy_cli/config.py
+++ b/tomopy_cli/config.py
@@ -937,14 +937,14 @@ def yaml_args(args, yaml_file, sample, cli_args=sys.argv):
     yaml_file = Path(yaml_file)
     # Check for bad files
     if not yaml_file.exists():
-        log.warning("YAML file does not exist: %s", yaml_file)
+        log.warning("  *** YAML file does not exist: %s", yaml_file)
         return args
     # Look for the requested key in a hierarchical manner
     with open(yaml_file, mode='r') as fp:
         extra_params = None
         yaml_data = yaml.safe_load(fp)
         if yaml_data is None:
-            log.warning("Invalid YAML file: %s", yaml_file)
+            log.warning("  *** Invalid YAML file: %s", yaml_file)
             return args
         keys_to_check = [sample] + [sample.relative_to(a) for a in sample.parents]
         for key in keys_to_check:

--- a/tomopy_cli/recon.py
+++ b/tomopy_cli/recon.py
@@ -23,7 +23,10 @@ def rec(params):
     
     data_shape = file_io.get_dx_dims(params)
     # Read parameters from YAML file
-    params = config.yaml_args(params, params.parameter_file, str(params.file_name))
+    try:
+        params = config.yaml_args(params, params.parameter_file, str(params.file_name))
+    except KeyError:
+        pass
     # Read parameters from DXchange file if requested
     params = file_io.auto_read_dxchange(params)
     if params.rotation_axis <= 0:


### PR DESCRIPTION
Fixed unit tests and a bug in "try" reconstructions when an extra_params file is present, but the given tomogram file name is not included.