### PR TITLE
Adding option to store meta data in recon hdf file

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -47,9 +47,20 @@ Update
 Dependencies
 ============
 
-Install the following package::
+Install `tomopy <https://tomopy.readthedocs.io/en/stable/>`_ 
+
+::
 
     $ conda install -c conda-forge tomopy
+
+
+install `meta <https://github.com/xray-imaging/meta>`_ 
+
+::
+
+    $ git clone https://github.com/xray-imaging/meta.git
+    $ cd meta
+    $ python setup install meta
 
 Optionally, *dxchange* may be needed for file I/O::
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,5 @@
+h5py
+meta
+tomopy
+dxchange
 opencv-python

--- a/tests/test_beamhardening.py
+++ b/tests/test_beamhardening.py
@@ -23,7 +23,7 @@ def make_params():
     params.filter_3_material = "none"
     params.file_name = HDF_FILE
     # params.file_name = HDF_FILE
-    # params.output_folder = "{file_name_parent}/_rec"
+    # params.save_folder = "{file_name_parent}/_rec"
     # params.parameter_file = os.devnull
     # params.rotation_axis = 32
     # params.file_type = 'standard'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,7 +19,7 @@ def make_params():
     params.reconstruction_type = "full"
     params.file_name = HDF_FILE
     params.config = Path("test_recon.conf")
-    params.output_folder = "{file_name_parent}/_rec"
+    params.save_folder = "{file_name_parent}/_rec"
     return params
 
 
@@ -27,7 +27,7 @@ class TestUpdateConfig(TestCase):
     def test_full_recon_config_hdf(self):
         """Test that the config file is saved for an HDF file."""
         params = make_params()
-        params.output_format = "hdf5"
+        params.save_format = "h5"
         output_dir = HDF_FILE.parent / "_rec"
         os.makedirs(output_dir)
         expected_config = output_dir / "test_tomogram_rec_test_recon.conf"
@@ -41,7 +41,7 @@ class TestUpdateConfig(TestCase):
     def test_full_recon_config_tiff_stack(self):
         """Test that the config file is saved for a stack of TIFFs."""
         params = make_params()
-        params.output_format = "tiff_stack"
+        params.save_format = "tiff"
         base_dir = HDF_FILE.parent / "_rec"
         os.makedirs(base_dir)
         output_dir = base_dir / "test_tomogram_rec"

--- a/tests/test_file_io.py
+++ b/tests/test_file_io.py
@@ -54,7 +54,7 @@ class FlipAndStitchTests(unittest.TestCase):
 
 
 class ReadParamTests(unittest.TestCase):
-F    test_hdf_file = TESTDIR / 'filter-tests.hdf5'
+    test_hdf_file = TESTDIR / 'filter-tests.hdf5'
     params_file = TESTDIR / 'extra_params.yaml'
     # Sample filters from 7-BM-B for 'open' and 'Cu_1000um' filters
     filter_open = np.array([[79, 112, 101, 110,] + [0,] * 252], dtype='int8')

--- a/tests/test_file_io.py
+++ b/tests/test_file_io.py
@@ -54,7 +54,7 @@ class FlipAndStitchTests(unittest.TestCase):
 
 
 class ReadParamTests(unittest.TestCase):
-    test_hdf_file = TESTDIR / 'filter-tests.hdf5'
+F    test_hdf_file = TESTDIR / 'filter-tests.hdf5'
     params_file = TESTDIR / 'extra_params.yaml'
     # Sample filters from 7-BM-B for 'open' and 'Cu_1000um' filters
     filter_open = np.array([[79, 112, 101, 110,] + [0,] * 252], dtype='int8')

--- a/tests/test_recon.py
+++ b/tests/test_recon.py
@@ -17,7 +17,7 @@ YAML_FILE = TEST_DIR / 'test_tomogram.yaml'
 def make_params():
     params = mock.MagicMock()
     params.file_name = HDF_FILE
-    params.output_folder = "{file_name_parent}/_rec"
+    params.save_folder = "{file_name_parent}/_rec"
     params.parameter_file = os.devnull
     params.rotation_axis = 32
     params.file_type = 'standard'
@@ -82,7 +82,7 @@ class ReconTests(ReconTestBase):
         """Check that a basic reconstruction completes and produces output tiff files."""
         params = make_params()
         params.reconstruction_type = 'full'
-        params.output_format = 'tiff_stack'
+        params.save_format = 'tiff'
         response = rec(params=params)
         # import pdb; pdb.set_trace()
         self.assertTrue(self.full_tiff_dir.exists())
@@ -90,7 +90,7 @@ class ReconTests(ReconTestBase):
     def test_hdf_output(self):
         params = make_params()
         params.reconstruction_type = 'full'
-        params.output_format = "hdf5"
+        params.save_format = "h5"
         response = rec(params=params)
         expected_hdf5path = self.output_hdf
         # Check that tiffs are not saved and HDF5 file is saved
@@ -105,7 +105,7 @@ class ReconTests(ReconTestBase):
         # Test with multiple chunks to ensure they're all written
         params = make_params()
         params.reconstruction_type = 'full'
-        params.output_format = 'hdf5'
+        params.save_format = 'hdf5'
         params.nsino_per_chunk = 16 # 4 chunks
         response = rec(params=params)
         expected_hdf5path = self.output_hdf
@@ -119,12 +119,12 @@ class ReconTests(ReconTestBase):
 
     def test_reconstruction_folder(self):
         params = make_params()
-        params.output_folder = "_rec"
+        params.save_folder = "_rec"
         output = reconstruction_folder(params)
         self.assertEqual(str(output), "_rec")
         # Check config parameters
         params = make_params()
-        params.output_folder = "_rec_{reconstruction_algorithm}/"
+        params.save_folder = "_rec_{reconstruction_algorithm}/"
         params.reconstruction_algorithm = "sirt"
         output = reconstruction_folder(params)
         self.assertEqual(str(output), "_rec_sirt")
@@ -132,14 +132,14 @@ class ReconTests(ReconTestBase):
         this_file = Path(__file__).resolve()
         params = make_params()
         params.file_name = str(this_file)
-        params.output_folder = "{file_name_parent}_rec/"
+        params.save_folder = "{file_name_parent}_rec/"
         output = reconstruction_folder(params)
         self.assertEqual(str(output), str(this_file.parent) + "_rec")
         # Check parent file name for a directory
         this_file = Path(__file__).resolve()
         params = make_params()
         params.file_name = str(this_file.parent) + '/'
-        params.output_folder = "{file_name_parent}_rec/"
+        params.save_folder = "{file_name_parent}_rec/"
         output = reconstruction_folder(params)
         self.assertEqual(str(output), str(this_file.parent) + "_rec")
 
@@ -194,7 +194,7 @@ class TryCenterTests(ReconTestBase):
         params = make_params()
         params.reconstruction_type = "try"
         params.center_search_width = 10
-        params.output_folder = "{file_name_parent}/_rec"
+        params.save_folder = "{file_name_parent}/_rec"
         params.parameter_file = os.devnull
         response = rec(params=params)
         self.assertTrue(self.output_dir.exists())
@@ -207,7 +207,7 @@ class TryCenterTests(ReconTestBase):
         params = make_params()
         params.reconstruction_type = "try"
         params.center_search_width = 10
-        params.output_folder = "{file_name_parent}/_rec"
+        params.save_folder = "{file_name_parent}/_rec"
         params.parameter_file = self.yaml_file
         # Create the YAML file
         opts = {
@@ -229,7 +229,7 @@ class TryCenterTests(ReconTestBase):
         params = make_params()
         params.reconstruction_type = "try"
         params.center_search_width = 10
-        params.output_folder = "{file_name_parent}/_rec"
+        params.save_folder = "{file_name_parent}/_rec"
         params.parameter_file = self.yaml_file
         # Create the YAML file
         opts = {
@@ -250,7 +250,7 @@ class TryCenterTests(ReconTestBase):
         params = make_params()
         params.reconstruction_type = "try"
         params.center_search_width = 10
-        params.output_folder = "{file_name_parent}/_rec"
+        params.save_folder = "{file_name_parent}/_rec"
         params.parameter_file = "/tmp/gweoiuwerw"
         response = rec(params=params)
         self.assertTrue(self.output_dir.exists())

--- a/tests/test_recon.py
+++ b/tests/test_recon.py
@@ -105,7 +105,7 @@ class ReconTests(ReconTestBase):
         # Test with multiple chunks to ensure they're all written
         params = make_params()
         params.reconstruction_type = 'full'
-        params.save_format = 'hdf5'
+        params.save_format = 'h5'
         params.nsino_per_chunk = 16 # 4 chunks
         response = rec(params=params)
         expected_hdf5path = self.output_hdf

--- a/tomopy_cli/config.py
+++ b/tomopy_cli/config.py
@@ -443,13 +443,13 @@ SECTIONS['reconstruction'] = {
         'default': 1.0,
         'type': float,
         'help': "Ratio of the mask’s diameter in pixels to the smallest edge size along given axis"},
-    'output-format': {
-        'default': 'tiff_stack',
+    'save-format': {
+        'default': 'tiff',
         'type': str,
         'help': "How to save the reconstructed data. Only applies when ``reconstruction-type == 'full'``.",
-        'choices': ['tiff_stack', 'hdf5'],
+        'choices': ['tiff', 'h5'],
         },
-    'output-folder': {
+    'save-folder': {
         'default': "{file_name_parent}_rec",
         'type': str,
         'help': ("Where to save the reconstructed data. Can accept other parameters "
@@ -858,7 +858,7 @@ def update_config(args, is_reconstruction=True):
     If *args.reconstruction_type* is "full" and *is_reconstruction* is
     true, then a new configuration file is created alongside the
     reconstructed data, with a path determined by whether
-    *args.output_format* is "tiff_stack" or "hdf5".
+    *args.save_format* is "tiff" or "h5".
 
     Parameters
     ==========
@@ -879,7 +879,7 @@ def update_config(args, is_reconstruction=True):
     is_full_recon = (is_reconstruction and args.reconstruction_type == "full")
     if is_full_recon:
         recon_dir = recon.reconstruction_folder(args)
-        if args.output_format == "hdf5":
+        if args.save_format == "h5":
             log_fname = recon_dir / "{}_rec_{}".format(data_file.stem, config_file.name)
         else:
             log_fname = recon_dir / "{}_rec".format(data_file.stem) / config_file.name

--- a/tomopy_cli/recon.py
+++ b/tomopy_cli/recon.py
@@ -141,7 +141,7 @@ def rec(params):
                 write_thread = threading.Thread(target=file_io.write_hdf5,
                                                 args = (rec,),
                                                 kwargs = {'fname': str(fname),
-                                                          'dname': '/exchange/recon',
+                                                          'dname': '/exchange/data',
                                                           'dest_idx': slice(strt, strt+rec.shape[0]),
                                                           'maxsize': (ds_end, *rec.shape[1:]),
                                                           'overwrite': iChunk==0})

--- a/tomopy_cli/recon.py
+++ b/tomopy_cli/recon.py
@@ -124,7 +124,7 @@ def rec(params):
         fpath = Path(params.file_name).resolve()
         if params.reconstruction_type == "full":
             recon_dir = recon_base_dir / "{}_rec".format(fpath.stem)
-            if params.output_format == 'tiff_stack':
+            if params.save_format == 'tiff':
                 fname = recon_dir / 'recon'
                 log.debug("Full tiff dir: %s", fname)
                 write_thread = threading.Thread(target=dxchange.write_tiff_stack,
@@ -132,7 +132,7 @@ def rec(params):
                                                 kwargs = {'fname': str(fname),
                                                           'start': strt,
                                                           'overwrite': True})
-            elif params.output_format == "hdf5":
+            elif params.save_format == "h5":
                 # HDF5 output
                 fname = "{}.hdf".format(recon_dir)
                 # file_io.write_hdf5(rec, fname=str(fname), dest_idx=slice(strt, strt+rec.shape[0]),
@@ -146,7 +146,7 @@ def rec(params):
                                                           'maxsize': (ds_end, *rec.shape[1:]),
                                                           'overwrite': iChunk==0})
             else:
-                log.error("  *** Unknown output_format '%s'", params.output_format)
+                log.error("  *** Unknown save_format '%s'", params.save_format)
                 fname = "<Not saved (bad output-format)>"
                 write_thread = None
             # Save the data to disk
@@ -169,7 +169,7 @@ def rec(params):
     for thread in write_threads:
         thread.join()
 
-    if params.output_format == "hdf5":
+    if params.save_format == "h5":
         log.info('adding meta data from the raw to the recon hdf file')
         log.info("  *** raw hdf: %s" % params.file_name)
         log.info("  *** rec hdf: %s" % fname)
@@ -543,7 +543,7 @@ def reconstruction_folder(params):
     
     """
     file_path = Path(params.file_name).resolve()
-    folder_fmt = params.output_folder
+    folder_fmt = params.save_folder
     # Format the folder name with the config parameters
     if file_path.is_dir():
         file_name_parent = file_path


### PR DESCRIPTION
the option `--output-format hdf5` now creates an hdf file containing the reconstruction and all meta data stored in the raw hdf file.

This option adds a dependency to [meta](https://github.com/xray-imaging/meta).

I propose to use  [meta](https://github.com/xray-imaging/meta) to replace all [auto_read_dexchage()](https://github.com/tomography/tomopy-cli/blob/b8f4ee9437687c2db36b76ae8bfad1cbded6b8e5/tomopy_cli/file_io.py#L328) functions.