### PR TITLE
Update config.py

### DIFF
--- a/tomopy_cli/config.py
+++ b/tomopy_cli/config.py
@@ -169,7 +169,7 @@ SECTIONS['file-reading'] = {
         'type': int,
         'help': 'Projection on which to start reconstructions'},
     'end-proj': {
-        'default': -1,
+        'default': 0,
         'type': int,
         'help': 'Projection on which to end reconstruction'},        
     'scintillator-auto': {


### PR DESCRIPTION
end-proj default value from -1 to 0.
Solves the following issue - mismatch of projection number and theta number


ValueError: There must be one angle for every projection.